### PR TITLE
[connman] add configurable online status url

### DIFF
--- a/connman/include/setting.h
+++ b/connman/include/setting.h
@@ -28,6 +28,9 @@
 extern "C" {
 #endif
 
+#define CONF_STATUS_URL_IPV6            "Ipv6StatusUrl"
+#define CONF_STATUS_URL_IPV4            "Ipv4StatusUrl"
+
 connman_bool_t connman_setting_get_bool(const char *key);
 char **connman_setting_get_string_list(const char *key);
 unsigned int *connman_setting_get_uint_list(const char *key);

--- a/connman/src/6to4.c
+++ b/connman/src/6to4.c
@@ -53,8 +53,6 @@ static unsigned int newlink_watch;
 static unsigned int newlink_flags;
 static int newlink_timeout_id;
 
-#define STATUS_URL "http://ipv6.connman.net/online/status.html"
-
 #ifndef IP_DF
 #define IP_DF		0x4000		/* Flag: "Don't Fragment"	*/
 #endif
@@ -315,7 +313,9 @@ static void tun_newlink(unsigned flags, unsigned change, void *user_data)
 		if (getenv("CONNMAN_WEB_DEBUG"))
 			g_web_set_debug(web, web_debug, "6to4");
 
-		web_request_id = g_web_request_get(web, STATUS_URL,
+		const char *url = connman_option_get_string(CONF_STATUS_URL_IPV6);
+
+		web_request_id = g_web_request_get(web, url,
 				web_result, NULL,  NULL);
 
 		newlink_timeout(NULL);

--- a/connman/src/main.conf
+++ b/connman/src/main.conf
@@ -95,3 +95,7 @@
 # re-enabling a technology, and after restarts and reboots.
 # Default value is false.
 # PersistentTetheringMode = false
+
+# set the online status url
+Ipv4StatusUrl = http://ipv4.connman.net/online/status.html
+Ipv6StatusUrl = http://ipv6.connman.net/online/status.html

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -30,9 +30,6 @@
 
 #include "connman.h"
 
-#define STATUS_URL_IPV4  "http://ipv4.connman.net/online/status.html"
-#define STATUS_URL_IPV6  "http://ipv6.connman.net/online/status.html"
-
 struct connman_wispr_message {
 	gboolean has_error;
 	const char *current_element;
@@ -864,10 +861,11 @@ static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context)
 
 	if (wp_context->type == CONNMAN_IPCONFIG_TYPE_IPV4) {
 		g_web_set_address_family(wp_context->web, AF_INET);
-		wp_context->status_url = STATUS_URL_IPV4;
+		wp_context->status_url = connman_option_get_string(CONF_STATUS_URL_IPV4);
+
 	} else {
 		g_web_set_address_family(wp_context->web, AF_INET6);
-		wp_context->status_url = STATUS_URL_IPV6;
+		wp_context->status_url = connman_option_get_string(CONF_STATUS_URL_IPV6);
 	}
 
 	for (i = 0; nameservers[i] != NULL; i++)


### PR DESCRIPTION
With this patch, can add something
in main.conf:
Ipv4StatusUrl = http://someurl.com/status.html
Ipv6StatusUrl = http://someurl.com/status.html

default connman's url are at:
http://ipv4.connman.net/online/status.html
http://ipv6.connman.net/online/status.html
even if nothing is set in config file
