### PR TITLE
Usage counters

### DIFF
--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -714,6 +714,8 @@ void __connman_service_notify(struct connman_service *service,
 			unsigned int rx_dropped, unsigned int tx_dropped);
 
 int __connman_service_counter_register(const char *counter);
+void __connman_service_counter_send_initial(const char *counter);
+void __connman_service_counter_reset_all(const char *type);
 void __connman_service_counter_unregister(const char *counter);
 
 #include <connman/session.h>

--- a/connman/src/counter.c
+++ b/connman/src/counter.c
@@ -102,6 +102,8 @@ int __connman_counter_register(const char *owner, const char *path,
 	counter->watch = g_dbus_add_disconnect_watch(connection, owner,
 					owner_disconnect, counter, NULL);
 
+    __connman_service_counter_send_initial(counter->path);
+
 	return 0;
 }
 

--- a/connman/src/manager.c
+++ b/connman/src/manager.c
@@ -360,6 +360,18 @@ static DBusMessage *unregister_counter(DBusConnection *conn,
 	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
 }
 
+static DBusMessage *reset_counters(DBusConnection *conn, DBusMessage *msg, void *data)
+{
+    DBG("conn %p", conn);
+
+    const char *type;
+    dbus_message_get_args(msg, NULL, DBUS_TYPE_STRING, &type, DBUS_TYPE_INVALID);
+
+    __connman_service_counter_reset_all(type);
+
+    return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
+}
+
 static DBusMessage *create_session(DBusConnection *conn,
 					DBusMessage *msg, void *data)
 {
@@ -466,6 +478,9 @@ static const GDBusMethodTable manager_methods[] = {
 	{ GDBUS_METHOD("UnregisterCounter",
 			GDBUS_ARGS({ "path", "o" }), NULL,
 			unregister_counter) },
+    { GDBUS_METHOD("ResetCounters",
+            GDBUS_ARGS({ "type", "s" }), NULL,
+            reset_counters) },
 	{ GDBUS_ASYNC_METHOD("CreateSession",
 			GDBUS_ARGS({ "settings", "a{sv}" },
 						{ "notifier", "o" }),


### PR DESCRIPTION
When a counter is first registered immediately send it the usage stats
of all known network services. This includes both currently available
and unavailable network services.

This is missing counter reset.
