### PR TITLE
wispr: Handle wispr redirect properly

### DIFF
--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -642,6 +642,8 @@ static gboolean wispr_manage_message(GWebResult *result,
 					wispr_portal_request_wispr_login,
 					wp_context) != -EINPROGRESS)
 			wispr_portal_error(wp_context);
+		else
+			return TRUE;
 
 		break;
 	case 120: /* Falling down */


### PR DESCRIPTION
Return true if agent invocation is successful after receiving
a valid wispr redirect message. Otherwise wispr_portal_web_result()
will proceed based on HTTP status code.

This was submitted to upstream as a29da8cc655910b890ec03fb89eecada10d15317
