### PR TITLE
[init] Added boot time requirement to be started after dbus

### DIFF
--- a/connman/src/connman.service.in
+++ b/connman/src/connman.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Connection service
-After=syslog.target
+Requires=dbus.service
+After=dbus.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
In current form connman crashes if dbus service dies. This has caused us problems in shutdown. This change makes sure that dbus service must be up and running while connman runs and shutdown order is so that connman is stopped before dbus is stopped.

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
