### PR TITLE
[connman] Point connman.service to correct environment file.

### DIFF
--- a/connman/src/connman.service.in
+++ b/connman/src/connman.service.in
@@ -6,7 +6,7 @@ After=dbus.service
 [Service]
 Type=notify
 Restart=on-failure
-EnvironmentFile=-/etc/tracing/connman
+EnvironmentFile=-/etc/tracing/connman/connman.tracing
 ExecStart=@prefix@/sbin/connmand -n --systemd $TRACING
 StandardOutput=null
 Restart=always


### PR DESCRIPTION
Installing connman-tracing is meant to enable tracing, but it doesn't
because the connman.service is pointing at the directory not the
environment file.

This will now cause a lot of logging to be produced.
