### PR TITLE
[connman] Proper D-Bus type for WEP key index in wpa_supplicant D-Bus AP...

### DIFF
--- a/connman/gsupplicant/supplicant.c
+++ b/connman/gsupplicant/supplicant.c
@@ -3046,7 +3046,7 @@ static void add_network_security_wep(DBusMessageIter *dict,
 					GSupplicantSSID *ssid)
 {
 	const char *auth_alg = "OPEN SHARED";
-	const char *key_index = "0";
+	const dbus_uint32_t key_index = 0;
 
 	supplicant_dbus_dict_append_basic(dict, "auth_alg",
 					DBUS_TYPE_STRING, &auth_alg);
@@ -3094,7 +3094,7 @@ static void add_network_security_wep(DBusMessageIter *dict,
 							&ssid->passphrase);
 
 		supplicant_dbus_dict_append_basic(dict, "wep_tx_keyidx",
-					DBUS_TYPE_STRING, &key_index);
+					DBUS_TYPE_UINT32, &key_index);
 	}
 }
 


### PR DESCRIPTION
[connman] Proper D-Bus type for WEP key index in wpa_supplicant D-Bus API messages

Fixes issues with wpa_supplicant 2.1 and wep.

https://lists.connman.net/pipermail/connman/2013-August/015599.html
