### PR TITLE
[connman] IP address collision fix

### DIFF
--- a/connman/src/ippool.c
+++ b/connman/src/ippool.c
@@ -297,7 +297,7 @@ update:
 		if (it == info)
 			continue;
 
-		if (!(it->start <= info->start || info->start <= it->end))
+		if (!(info->start >= it->start && info->start <= it->end))
 			continue;
 
 		if (it->pool != NULL && it->pool->collision_cb != NULL)


### PR DESCRIPTION
Fixes a problem with tethering switching off when MMS context is activated. Or at least one of the scenarios when it might happen.

This is actually a merge of this commit from kernel.org:

http://git.kernel.org/cgit/network/connman/connman.git/commit/?id=60ee35f0

The IP address collision was incorrectly checked. The check reported collisions even if there was none. This had the effect that if the tethering uplink connection went down and then up, the tethering address was released and then new address was allocated without a reason.
