### PR TITLE
Remove After=syslog.target from systemd unit files and add requirements ...

### DIFF
--- a/connman/vpn/connman-vpn.service.in
+++ b/connman/vpn/connman-vpn.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=ConnMan VPN service
-After=syslog.target
+Requires=dbus.socket
+After=dbus.socket
 
 [Service]
 Type=dbus


### PR DESCRIPTION
...to dbus.socket instead.

Related systemd documentation:
http://www.freedesktop.org/wiki/Software/systemd/syslog/

"Newer systemd versions (v35+) do not support non-socket-activated
syslog daemons anymore and we do no longer recommend people to order
their units after syslog.target."

Related systemd commit:
http://cgit.freedesktop.org/systemd/systemd/commit/?id=4b7b2efb69943aae0f8287df6e28b637c50fe318

Signed-off-by: Marko Saukko marko.saukko@jolla.com
