### PR TITLE
[connman] walled garden check with http-status code 204

### DIFF
--- a/connman/src/connman.service.in
+++ b/connman/src/connman.service.in
@@ -6,7 +6,7 @@ Before=remote-fs.target
 
 [Service]
 Type=notify
-Restart=on-failure
+Restart=always
 EnvironmentFile=-/etc/tracing/connman/connman.tracing
 ExecStart=@prefix@/sbin/connmand -n --systemd $TRACING
 StandardOutput=null

--- a/connman/vpn/connman-vpn.service.in
+++ b/connman/vpn/connman-vpn.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=ConnMan VPN service
-After=syslog.target
+Requires=dbus.socket
+After=dbus.socket
 
 [Service]
 Type=dbus


### PR DESCRIPTION
The current way of checking online status with http-headers is broken with number of operators removing headers with their proxies. Doing a check againts return code (204 = no content) works much more better.

This modification to work requires configuration changes: Ipv4StatusUrl to http://ipv4.jolla.com/return_204 & Ipv6StatusUrl to http://ipv6.jolla.com/return_204.
