### PR TITLE
Add --nobacktrace option because we have our own crash reporter tool tha...

### DIFF
--- a/connman/src/connman.service.in
+++ b/connman/src/connman.service.in
@@ -8,7 +8,7 @@ Before=remote-fs.target
 Type=notify
 Restart=always
 EnvironmentFile=-/etc/tracing/connman/connman.tracing
-ExecStart=@prefix@/sbin/connmand -n --systemd $TRACING
+ExecStart=@prefix@/sbin/connmand -n --nobacktrace --systemd $TRACING
 StandardOutput=null
 
 [Install]


### PR DESCRIPTION
...t catches these

and with this option those are not caught.

[debugging] Add --nobacktrace option to make crash reporter tool get connman crashes.

Signed-off-by: Marko Saukko marko.saukko@jolla.com
