### PR TITLE
[connman] Fix offlinemode after reboot.

### DIFF
--- a/connman/src/technology.c
+++ b/connman/src/technology.c
@@ -1697,18 +1697,17 @@ done:
 				softblock, hardblock, true))
 		return 0;
 
-	if (global_offlinemode)
-		return 0;
-
 	/*
 	 * Depending on softblocked state we unblock/block according to
 	 * offlinemode and persistente state.
 	 */
 	if (technology->softblocked &&
+				!global_offlinemode &&
 				technology->enable_persistent)
 		return __connman_rfkill_block(type, false);
 	else if (!technology->softblocked &&
-				!technology->enable_persistent)
+		(global_offlinemode ||
+				!technology->enable_persistent))
 		return __connman_rfkill_block(type, true);
 
 	return 0;


### PR DESCRIPTION
Fixes wlan and bluetooth being powered on after reboot when in
offlinemode.

This change essentially reverts:

commit c3c35b8842b24546b0424ca1d83ca919ffd2427c
Author: Jukka Rissanen jukka.rissanen@linux.intel.com
Date:   Mon Jul 15 17:32:56 2013 +0300

```
technology: Checking offline mode separately when rfkill device is
added
```

made to connman 1.17
