### PR TITLE
[connman] Fix magic after merge conflict.

### DIFF
--- a/connman/tools/stats-tool.c
+++ b/connman/tools/stats-tool.c
@@ -48,7 +48,7 @@
 #define TFR
 #endif
 
-#define MAGIC 0xFA00B916
+#define MAGIC 0xFA01B916
 
 struct connman_stats_data {
 	uint64_t rx_packets;


### PR DESCRIPTION
The stats data file magic number was changed to reflect the new 64 bit
data format. With the mismatched magic stats-tools would re-initialise
the data files when inspecting them, clearing all data.
