### PR TITLE
[connman] Return an in progress error if the service is already connecti...

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -4258,7 +4258,7 @@ static DBusMessage *connect_service(DBusConnection *conn,
 
 	DBG("service %p", service);
 
-	if (service->pending)
+	if (service->pending || is_connecting(service) || is_connected(service))
 		return __connman_error_in_progress(msg);
 
 	for (list = service_list; list; list = list->next) {


### PR DESCRIPTION
...ng.

If the network service is already connecting return an in progress
error and do nothing. Previously only the pending variable was tested
indicating that a previous DBus call started the connection. This
variable is not set for an internally initiated connection.

If the connect_sevice call is not aborted it is possible that the
service connection will be needlessly aborted when looking for an
available interface.
