### PR TITLE
ipconfig: iterate safely over ipconfig_list

### DIFF
--- a/connman/src/ipconfig.c
+++ b/connman/src/ipconfig.c
@@ -477,7 +477,7 @@ void __connman_ipconfig_newlink(int index, unsigned short type,
 						struct rtnl_link_stats64 *stats)
 {
 	struct connman_ipdevice *ipdevice;
-	GList *list;
+	GList *list, *ipconfig_copy;
 	GString *str;
 	bool up = false, down = false;
 	bool lower_up = false, lower_down = false;
@@ -556,7 +556,8 @@ update:
 
 	g_string_free(str, TRUE);
 
-	for (list = g_list_first(ipconfig_list); list;
+	ipconfig_copy = g_list_copy(ipconfig_list);
+	for (list = g_list_first(ipconfig_copy); list;
 						list = g_list_next(list)) {
 		struct connman_ipconfig *ipconfig = list->data;
 
@@ -576,6 +577,7 @@ update:
 		if (down && ipconfig->ops->down)
 			ipconfig->ops->down(ipconfig, ifname);
 	}
+	g_list_free(ipconfig_copy);
 
 	if (lower_up)
 		__connman_ipconfig_lower_up(ipdevice);


### PR DESCRIPTION
The following valgrind report appears when a network toggled from
enabled to disabled and back; it is due to ipconfig_list being
modified by functions called in the loop while iterating over the
list. When the current list element gets deleted during iteration,
g_list_next() cannot be safely called anymore.

Fixed by making a shallow copy of the list for iteration purposes.

==1638== Invalid read of size 4
==1638==    at 0x542E0: __connman_ipconfig_newlink (ipconfig.c:560)
==1638==    by 0x633F7: process_newlink (rtnl.c:445)
==1638==    by 0x6424F: netlink_event (rtnl.c:958)
==1638==    by 0x4907733: g_io_unix_dispatch (giounix.c:167)
==1638==    by 0x48AC55B: g_main_context_dispatch (gmain.c:3054)
==1638==    by 0x48AC85F: g_main_context_iterate.part.17 (gmain.c:3701)
==1638==    by 0x48ACEB3: g_main_loop_run (gmain.c:3894)
==1638==    by 0x14957: main (main.c:739)
==1638==  Address 0x50df6fc is 4 bytes inside a block of size 12 free'd
==1638==    at 0x483752C: free (vg_replace_malloc.c:446)
==1638==    by 0x48B418B: g_free (gmem.c:252)
==1638==    by 0x48A758F: g_list_remove (glist.c:480)
==1638==    by 0x55AB7: __connman_ipconfig_disable (ipconfig.c:1691)
==1638==    by 0x4376F: service_lower_down (service.c:6703)
==1638==    by 0x54373: __connman_ipconfig_newlink (ipconfig.c:575)
==1638==    by 0x633F7: process_newlink (rtnl.c:445)
==1638==    by 0x6424F: netlink_event (rtnl.c:958)
==1638==    by 0x4907733: g_io_unix_dispatch (giounix.c:167)
==1638==    by 0x48AC55B: g_main_context_dispatch (gmain.c:3054)
==1638==    by 0x48AC85F: g_main_context_iterate.part.17 (gmain.c:3701)
==1638==    by 0x48ACEB3: g_main_loop_run (gmain.c:3894)
==1638==
