### PR TITLE
agent: fix agent message handling bugs.

### DIFF
--- a/connman/src/agent-connman.c
+++ b/connman/src/agent-connman.c
@@ -354,6 +354,9 @@ static void request_input_login_reply(DBusMessage *reply, void *user_data)
 	char *key;
 	DBusMessageIter iter, dict;
 
+	if (!reply)
+		goto out;
+
 	if (dbus_message_get_type(reply) == DBUS_MESSAGE_TYPE_ERROR) {
 		error = dbus_message_get_error_name(reply);
 		goto done;
@@ -401,6 +404,8 @@ done:
 					username, password,
 					FALSE, NULL, error,
 					username_password_reply->user_data);
+
+out:
 	g_free(username_password_reply);
 }
 

--- a/connman/src/agent.c
+++ b/connman/src/agent.c
@@ -112,6 +112,17 @@ static void agent_request_free(struct connman_agent_request *request)
 	g_free(request);
 }
 
+static void agent_finalize_pending(struct connman_agent *agent,
+				DBusMessage *reply)
+{
+	struct connman_agent_request *pending = agent->pending;
+	if (pending) {
+		agent->pending = NULL;
+		pending->callback(reply, pending->user_data);
+		agent_request_free(pending);
+	}
+}
+
 static void agent_receive_message(DBusPendingCall *call, void *user_data);
 
 static int agent_send_next_request(struct connman_agent *agent)
@@ -146,9 +157,7 @@ static int agent_send_next_request(struct connman_agent *agent)
 	return 0;
 
 fail:
-	agent->pending->callback(NULL, agent->pending->user_data);
-	agent_request_free(agent->pending);
-	agent->pending = NULL;
+	agent_finalize_pending(agent, NULL);
 	return -ESRCH;
 }
 
@@ -191,11 +200,8 @@ static void agent_receive_message(DBusPendingCall *call, void *user_data)
 		send_cancel_request(agent, agent->pending);
 	}
 
-	agent->pending->callback(reply, agent->pending->user_data);
+	agent_finalize_pending(agent, reply);
 	dbus_message_unref(reply);
-
-	agent_request_free(agent->pending);
-	agent->pending = NULL;
 
 	err = agent_send_next_request(agent);
 	if (err < 0 && err != -EBUSY)
@@ -457,9 +463,7 @@ static void cancel_all_requests(struct connman_agent *agent)
 		if (agent->pending->call)
 			send_cancel_request(agent, agent->pending);
 
-		agent->pending->callback(NULL, agent->pending->user_data);
-		agent_request_free(agent->pending);
-		agent->pending = NULL;
+		agent_finalize_pending(agent, NULL);
 	}
 
 	for (list = agent->queue; list; list = list->next) {
@@ -522,12 +526,7 @@ void connman_agent_cancel(void *user_context)
 			if (agent->pending->call)
 				send_cancel_request(agent, agent->pending);
 
-			agent->pending->callback(NULL,
-						agent->pending->user_data);
-
-			agent_request_free(agent->pending);
-
-			agent->pending = NULL;
+			agent_finalize_pending(agent, NULL);
 
 			err = agent_send_next_request(agent);
 			if (err < 0 && err != -EBUSY)


### PR DESCRIPTION
It could happen that cleaning up a pending message in
agent_receive_message() would as a side effect zero service reference
count via driver context unref function pointer, and service cleanup
would call connman_agent_cancel() which would try to clean up the
pending message for the second time.

Fixed by decoupling the pointer to the pending request from the agent
structure before calling agent_request_free().

Also, added null message pointer handling to agent-connman.c callback
function request_input_login_reply().

[connman] Fix agent message handling bugs.
