### PR TITLE
supplicant: rewrite pending DBus call handling

### DIFF
--- a/connman/gsupplicant/dbus.h
+++ b/connman/gsupplicant/dbus.h
@@ -71,10 +71,10 @@ int supplicant_dbus_method_call(const char *path,
 				const char *interface, const char *method,
 				supplicant_dbus_setup_function setup,
 				supplicant_dbus_result_function function,
-				void *user_data, DBusPendingCall **pending,
-				dbus_int32_t *slot);
+				void *user_data, 
+				void *caller);
 
-void supplicant_dbus_call_callback(DBusPendingCall *call, dbus_int32_t slot);
+void supplicant_dbus_method_call_cancel_all(void *caller);
 
 void supplicant_dbus_property_append_basic(DBusMessageIter *iter,
 					const char *key, int type, void *val);

--- a/connman/gsupplicant/supplicant.c
+++ b/connman/gsupplicant/supplicant.c
@@ -172,8 +172,6 @@ struct _GSupplicantInterface {
 	GHashTable *net_mapping;
 	GHashTable *bss_mapping;
 	void *data;
-	DBusPendingCall *pending_call;
-	dbus_int32_t pending_slot;
 };
 
 struct g_supplicant_bss {
@@ -1963,7 +1961,7 @@ static void interface_added(DBusMessageIter *iter, void *user_data)
 
 	supplicant_dbus_method_call(path,
 			SUPPLICANT_INTERFACE ".Interface.P2PDevice", "Flush",
-			NULL, interface_p2p_flush, interface, NULL, NULL);
+			NULL, interface_p2p_flush, interface, NULL);
 
 	dbus_message_iter_next(iter);
 	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_INVALID) {
@@ -1988,17 +1986,8 @@ static void interface_removed(DBusMessageIter *iter, void *user_data)
 		return;
 
 	interface = g_hash_table_lookup(interface_table, path);
-	if (interface && interface->pending_call) {
-		dbus_pending_call_cancel(interface->pending_call);
-		SUPPLICANT_DBG("Cancelled pending DBus call %p slot %d",
-			interface->pending_call, interface->pending_slot);
-
-		supplicant_dbus_call_callback(interface->pending_call,
-					interface->pending_slot);
-
-		interface->pending_call = NULL;
-		interface->pending_slot = -1;
-	}
+	SUPPLICANT_DBG("Cancelling any pending DBus calls");
+	supplicant_dbus_method_call_cancel_all(interface);
 
 	g_hash_table_remove(interface_table, path);
 }
@@ -2842,8 +2831,6 @@ static void interface_get_result(const char *error,
 		goto done;
 	}
 
-	interface->pending_call = NULL;
-
 	if (data->callback)
 		data->callback(0, interface, data->user_data);
 
@@ -2864,7 +2851,7 @@ create:
 						"CreateInterface",
 						interface_create_params,
 						interface_create_result, data,
-						NULL, NULL);
+						NULL);
 	if (err == 0)
 		return;
 
@@ -2915,7 +2902,7 @@ int g_supplicant_interface_create(const char *ifname, const char *driver,
 						"GetInterface",
 						interface_get_params,
 						interface_get_result, data,
-						NULL, NULL);
+						NULL);
 	if (ret < 0)
 		dbus_free(data);
 
@@ -2945,9 +2932,6 @@ static void interface_remove_result(const char *error,
 	err = 0;
 
 done:
-	if (interface_exists(data->interface, data->path))
-		data->interface->pending_call = NULL;
-
 	g_free(data->path);
 
 	if (data->callback)
@@ -2979,17 +2963,8 @@ int g_supplicant_interface_remove(GSupplicantInterface *interface,
 	if (!system_available)
 		return -EFAULT;
 
-	if (interface->pending_call) {
-		dbus_pending_call_cancel(interface->pending_call);
-		SUPPLICANT_DBG("Cancelled pending DBus call %p slot %d",
-			interface->pending_call, interface->pending_slot);
-
-		supplicant_dbus_call_callback(interface->pending_call,
-					interface->pending_slot);
-
-		interface->pending_call = NULL;
-		interface->pending_slot = -1;
-	}
+	SUPPLICANT_DBG("Cancelling any pending DBus calls");
+	supplicant_dbus_method_call_cancel_all(interface);
 
 	data = dbus_malloc0(sizeof(*data));
 	if (!data)
@@ -3005,7 +2980,7 @@ int g_supplicant_interface_remove(GSupplicantInterface *interface,
 						"RemoveInterface",
 						interface_remove_params,
 						interface_remove_result, data,
-						NULL, NULL);
+						NULL);
 	if (ret < 0) {
 		g_free(data->path);
 		dbus_free(data);
@@ -3028,8 +3003,6 @@ static void interface_scan_result(const char *error,
 	if (interface_exists(data->interface, data->path)) {
 		if (!data->interface->ready)
 			err = -ENOLINK;
-
-		data->interface->pending_call = NULL;
 	}
 
 	g_free(data->path);
@@ -3226,7 +3199,7 @@ int g_supplicant_interface_scan(GSupplicantInterface *interface,
 	ret = supplicant_dbus_method_call(interface->path,
 			SUPPLICANT_INTERFACE ".Interface", "Scan",
 			interface_scan_params, interface_scan_result, data,
-			&interface->pending_call, &interface->pending_slot);
+			interface);
 
 	if (ret < 0) {
 		g_free(data->path);
@@ -3246,9 +3219,6 @@ static void interface_autoscan_result(const char *error,
 		SUPPLICANT_DBG("error %s", error);
 		err = -EIO;
 	}
-
-	if (interface_exists(data->interface, data->interface->path))
-		data->interface->pending_call = NULL;
 
 	g_free(data->path);
 
@@ -3288,8 +3258,7 @@ int g_supplicant_interface_autoscan(GSupplicantInterface *interface,
 			SUPPLICANT_INTERFACE ".Interface", "AutoScan",
 			interface_autoscan_params,
 			interface_autoscan_result, data,
-			&interface->pending_call,
-			&interface->pending_slot);
+			interface);
 	if (ret < 0) {
 		g_free(data->path);
 		dbus_free(data);
@@ -3338,9 +3307,6 @@ static void interface_select_network_result(const char *error,
 		err = parse_supplicant_error(iter);
 	}
 
-	if (interface_exists(data->interface, data->path))
-		data->interface->pending_call = NULL;
-
 	g_free(data->path);
 
 	if (data->callback)
@@ -3384,8 +3350,7 @@ static void interface_add_network_result(const char *error,
 			SUPPLICANT_INTERFACE ".Interface", "SelectNetwork",
 			interface_select_network_params,
 			interface_select_network_result, data,
-			&interface->pending_call,
-			&interface->pending_slot);
+			interface);
 
 	return;
 
@@ -3393,8 +3358,6 @@ error:
 	SUPPLICANT_DBG("AddNetwork error %s", error);
 
 	if (interface_exists(data->interface, data->interface->path)) {
-		interface->pending_call = NULL;
-
 		err = parse_supplicant_error(iter);
 		if (data->callback)
 			data->callback(err, data->interface, data->user_data);
@@ -3888,7 +3851,7 @@ static void wps_start(const char *error, DBusMessageIter *iter, void *user_data)
 	supplicant_dbus_method_call(data->interface->path,
 			SUPPLICANT_INTERFACE ".Interface.WPS", "Start",
 			interface_add_wps_params,
-			interface_wps_start_result, data, NULL, NULL);
+			interface_wps_start_result, data, NULL);
 }
 
 static void wps_process_credentials(DBusMessageIter *iter, void *user_data)
@@ -3941,8 +3904,7 @@ int g_supplicant_interface_connect(GSupplicantInterface *interface,
 			SUPPLICANT_INTERFACE ".Interface", "AddNetwork",
 			interface_add_network_params,
 			interface_add_network_result, data,
-			&interface->pending_call,
-			&interface->pending_slot);
+			interface);
 
 	if (ret < 0) {
 		g_free(data->path);
@@ -3967,9 +3929,6 @@ static void network_remove_result(const char *error,
 						error) == 0)
 			result = -ECONNABORTED;
 	}
-
-	if (interface_exists(data->interface, data->path))
-		data->interface->pending_call = NULL;
 
 	g_free(data->path);
 
@@ -3998,7 +3957,7 @@ static int network_remove(struct interface_data *data)
 	return supplicant_dbus_method_call(interface->path,
 			SUPPLICANT_INTERFACE ".Interface", "RemoveNetwork",
 			network_remove_params, network_remove_result, data,
-			&interface->pending_call, &interface->pending_slot);
+			interface);
 }
 
 static void interface_disconnect_result(const char *error,
@@ -4015,9 +3974,6 @@ static void interface_disconnect_result(const char *error,
 						error) == 0)
 			result = -ECONNABORTED;
 	}
-
-	if (interface_exists(data->interface, data->path))
-		data->interface->pending_call = NULL;
 
 	if (result < 0 && data->callback) {
 		data->callback(result, data->interface, data->user_data);
@@ -4071,7 +4027,7 @@ int g_supplicant_interface_disconnect(GSupplicantInterface *interface,
 	ret = supplicant_dbus_method_call(interface->path,
 			SUPPLICANT_INTERFACE ".Interface", "Disconnect",
 			NULL, interface_disconnect_result, data,
-			&interface->pending_call, &interface->pending_slot);
+			interface);
 
 	if (ret < 0) {
 		g_free(data->path);
@@ -4097,7 +4053,6 @@ static void interface_p2p_find_result(const char *error,
 			err = -ENOLINK;
 		if (!err)
 			data->interface->p2p_finding = true;
-		data->interface->pending_call = NULL;
 	}
 
 	if (data->callback)
@@ -4141,8 +4096,7 @@ int g_supplicant_interface_p2p_find(GSupplicantInterface *interface,
 	ret = supplicant_dbus_method_call(interface->path,
 			SUPPLICANT_INTERFACE ".Interface.P2PDevice", "Find",
 			interface_p2p_find_params, interface_p2p_find_result,
-			data, &interface->pending_call,
-			&interface->pending_slot);
+			data, interface);
 	if (ret < 0) {
 		g_free(data->path);
 		dbus_free(data);
@@ -4162,7 +4116,7 @@ int g_supplicant_interface_p2p_stop_find(GSupplicantInterface *interface)
 
 	return supplicant_dbus_method_call(interface->path,
 		SUPPLICANT_INTERFACE ".Interface.P2PDevice", "StopFind",
-		NULL, NULL, NULL, NULL, NULL);
+		NULL, NULL, NULL, NULL);
 }
 
 static const char *g_supplicant_rule0 = "type=signal,"
@@ -4265,7 +4219,7 @@ static void unregister_remove_interface(gpointer key, gpointer value,
 					SUPPLICANT_INTERFACE,
 					"RemoveInterface",
 					unregister_interface_remove_params,
-					NULL, interface->path, NULL, NULL);
+					NULL, interface->path, NULL);
 }
 
 void g_supplicant_unregister(const GSupplicantCallbacks *callbacks)


### PR DESCRIPTION
It is possible to overwrite the pending_call and pending_slot fields
in the GSupplicantInterface structure by making a new supplicant
related DBus call while an older call is still ongoing. This causes
problems with cleanup at interface removal time, as the older call is
not canceled and its reply processing may access already freed memory.

Fixed by having supplicant DBus code keep track of pending calls in a
list which is updated when call replys are processed. Supplicant code
can request cancellation of all pending calls for a particular
interface when needed.

[connman] supplicant: rewrite pending DBus call handling
