### PR TITLE
[connman] explicitly allow dns server to be created when no services are

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -2706,7 +2706,7 @@ bool __connman_service_index_is_split_routing(int index)
         struct connman_service *service;
 
 	if (index < 0)
-		return false;
+		return true;
 
 	service = __connman_service_lookup_from_index(index);
 	if (!service)


### PR DESCRIPTION
connected.

This allows the use of FallbackNameservers when there is no connman
connection. i.e. a usb network not handled by connman to be able to use dns
