### PR TITLE
wifi: cancel autoscan timeout when removing device

### DIFF
--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -293,6 +293,8 @@ static void wifi_remove(struct connman_device *device)
 	if (!wifi)
 		return;
 
+	stop_autoscan(device);
+
 	iface_list = g_list_remove(iface_list, wifi);
 
 	check_p2p_technology();


### PR DESCRIPTION
Usually autoscan is cancelled when the device is disabled, but when
wpa_supplicant leaves D-Bus wifi_disable() isn't called and thus
autoscan timeout isn't cleared. The timeout callback may access
released memory when it's activated.

Add stop_autoscan() call to wifi_remove() to make sure there are no
pending timeouts when the autoscan struct is released.
