### PR TITLE
[connman] allow user input request signal when using autoconnect.

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -4320,13 +4320,14 @@ static DBusMessage *connect_service(DBusConnection *conn,
 	err = __connman_service_connect(service,
 			CONNMAN_SERVICE_CONNECT_REASON_USER);
 
-	if (err == -EINPROGRESS)
+    if (err == -EINPROGRESS)
 		return NULL;
 
-	dbus_message_unref(service->pending);
+	if (err != -EINVAL)
+        dbus_message_unref(service->pending);
 	service->pending = NULL;
 
-	if (err < 0)
+	if (err > 0)
 		return __connman_error_failed(msg, -err);
 
 	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);


### PR DESCRIPTION
If passphrase gets changed, it needs to pass on the user Input request
signal to clients to be able to re-autoconnect.
