### PR TITLE
Hack to get wifi to work after connman has crashed

### DIFF
--- a/connman/src/device.c
+++ b/connman/src/device.c
@@ -1437,6 +1437,8 @@ static void cleanup_devices(void)
 	g_strfreev(interfaces);
 }
 
+extern void wifi_cleanup(void);
+
 int __connman_device_init(const char *device, const char *nodevice)
 {
 	DBG("");
@@ -1447,6 +1449,10 @@ int __connman_device_init(const char *device, const char *nodevice)
 	if (nodevice)
 		nodevice_filter = g_strsplit(nodevice, ",", -1);
 
+	/* wpa_supplicant interfaces must be removed prior to bringing wifi
+	 * interfaces down. Otherwise supplicant gets into INTERFACE_DISABLED
+	 * state and wifi won't work. */
+	wifi_cleanup();
 	cleanup_devices();
 
 	return 0;


### PR DESCRIPTION
Normally, after connman crashes and gets restarted by systemd, wifi connectivity stops working until the phone is rebooted (or connman is shut down gracefully and restarted with systemctl stop/start but users don't know and don't want to know how to do that).

It appears that wpa_supplicant interfaces must be removed prior to bringing wifi interfaces down (which is something connman does every time at startup); otherwise supplicant gets into INTERFACE_DISABLED state and nothing works. During the graceful shutdown, supplicant interface gets removed; if connman suddenly dies, it stays alive.

This hack makes sure that interfaces are removed before cleanup_devices() is called, thus allowing wifi connectivity to recover from the connman crash.
