### PR TITLE
dhcp: fixed memory leak in remove_option_value

### DIFF
--- a/connman/gdhcp/client.c
+++ b/connman/gdhcp/client.c
@@ -1130,6 +1130,7 @@ static void remove_option_value(gpointer data)
 	GList *option_value = data;
 
 	g_list_foreach(option_value, remove_value, NULL);
+	g_list_free(option_value);
 }
 
 GDHCPClient *g_dhcp_client_new(GDHCPType type,


### PR DESCRIPTION
==2636== 24 bytes in 2 blocks are definitely lost in loss record 140 of 274
==2636==    at 0x4838AB0: malloc (vg_replace_malloc.c:270)
==2636==    by 0x48B4023: g_malloc (gmem.c:159)
==2636==    by 0x48D08EB: g_slice_alloc (gslice.c:1003)
==2636==    by 0x48A7E8B: g_list_append (glist.c:232)
==2636==    by 0x19877: get_option_value_list (client.c:1867)
==2636==    by 0x1A5AF: get_request (client.c:2216)
==2636==    by 0x1ABC7: listener_event (client.c:2362)
==2636==    by 0x4907733: g_io_unix_dispatch (giounix.c:167)
==2636==    by 0x48AC55B: g_main_context_dispatch (gmain.c:3054)
==2636==    by 0x48AC85F: g_main_context_iterate.part.17 (gmain.c:3701)
==2636==    by 0x48ACEB3: g_main_loop_run (gmain.c:3894)
==2636==    by 0x51EF7: main (main.c:739)
