### PR TITLE
ofono: fixed memory leak

### DIFF
--- a/connman/plugins/ofono.c
+++ b/connman/plugins/ofono.c
@@ -760,6 +760,10 @@ static void extract_ipv4_settings(DBusMessageIter *array,
 	const char *interface = NULL;
 	int index = -1;
 
+	connman_ipaddress_free(context->ipv4_address);
+	context->ipv4_address = NULL;
+	context->index = -1;
+
 	if (dbus_message_iter_get_arg_type(array) != DBUS_TYPE_ARRAY)
 		return;
 
@@ -858,6 +862,10 @@ static void extract_ipv6_settings(DBusMessageIter *array,
 	char *nameservers = NULL;
 	const char *interface = NULL;
 	int index = -1;
+
+	connman_ipaddress_free(context->ipv6_address);
+	context->ipv6_address = NULL;
+	context->index = -1;
 
 	if (dbus_message_iter_get_arg_type(array) != DBUS_TYPE_ARRAY)
 		return;


### PR DESCRIPTION
==8697== 156 (72 direct, 84 indirect) bytes in 3 blocks are definitely lost in loss record 233 of 270
==8697==    at 0x4838AB0: malloc (vg_replace_malloc.c:270)
==8697==    by 0x48B426F: g_try_malloc0 (gmem.c:335)
==8697==    by 0xBFC17: connman_ipaddress_alloc (ipaddress.c:40)
==8697==    by 0x40117: extract_ipv4_settings (ofono.c:831)
==8697==    by 0x4136B: context_changed (ofono.c:1212)
==8697==    by 0xC4943: signal_filter (watch.c:406)
==8697==    by 0xC4EEB: message_filter (watch.c:551)
==8697==    by 0x4975F47: dbus_connection_dispatch (dbus-connection.c:4631)
==8697==    by 0xC31F7: message_dispatch (mainloop.c:72)
==8697==    by 0x48A8647: g_idle_dispatch (gmain.c:5205)
==8697==    by 0x48AC55B: g_main_context_dispatch (gmain.c:3054)
==8697==    by 0x48AC85F: g_main_context_iterate.part.17 (gmain.c:3701)
