### PR TITLE
[connman] service: Fix D-Bus return value when connecting a service

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -4324,16 +4324,14 @@ static DBusMessage *connect_service(DBusConnection *conn,
 	err = __connman_service_connect(service,
 			CONNMAN_SERVICE_CONNECT_REASON_USER);
 
-	if (err < 0 && err != -EINPROGRESS) {
-		if (service->pending) {
-			dbus_message_unref(service->pending);
-			service->pending = NULL;
-
-			return __connman_error_failed(msg, -err);
-		}
-
+	if (err == -EINPROGRESS)
 		return NULL;
-	}
+
+	dbus_message_unref(service->pending);
+	service->pending = NULL;
+
+	if (err < 0)
+		return __connman_error_failed(msg, -err);
 
 	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
 }


### PR DESCRIPTION
When the service is instantly connected or an error occured, remove
the pending call and report success or failure immediately to the
caller. When the connect procedure indicates -EINPROGRESS, the
caller will be informed later and no D-Bus reply is to be sent from
this function.

The service pending call needs to be set when calling
__connman_service_connect() as later stages in the code will decide
whether to ask an Agent for input based on its non-NULL value.

Reported by Aaron McCarthy aaron.mccarthy@jolla.com
