### PR TITLE
[connman] fix scan when no networks.

### DIFF
--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -609,12 +609,12 @@ static int throw_wifi_scan(struct connman_device *device,
 		return -ENODEV;
 
 	struct connman_network *network = wifi->network;
-	if (!network)
-		return -ENODEV;
-
+	if (network && connman_network_get_associating(network)) {
+		return -EBUSY;
+	}
 	DBG("device %p %p", device, wifi->interface);
 
-	if (wifi->tethering || connman_network_get_associating(network))
+	if (wifi->tethering)
 		return -EBUSY;
 
 	if (connman_device_get_scanning(device))


### PR DESCRIPTION
Previous change here would block scanning until a network would be found. There can be no network found until a scan is performed.
