### PR TITLE
[connman] loosen the autoconnect failure clamp.

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -3957,9 +3957,7 @@ DBG("state %d, failure_connect_interval %d"
     ,service->state,failure_connect_interval);
 
 		if (service->state == CONNMAN_SERVICE_STATE_FAILURE) {
-			if (failure_connect_interval < 0) {
-				continue;
-			} else if (failure_connect_interval == 0) {
+			if (failure_connect_interval <= 0) {
 				failure_connect_interval = 5;
 				g_timeout_add_seconds((guint)failure_connect_interval, connect_failure_timeout, NULL);
 			}


### PR DESCRIPTION
This fixes the condition when on the edge of a low signal, the
autoconnect keeps attempting to connect, Whereas before it would try
once, and then be locked out, until user manually connected.
