### PR TITLE
[connman] Check interface validity before setting regdom

### DIFF
--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -1317,7 +1317,7 @@ static int wifi_set_regdom(struct connman_device *device, const char *alpha2)
 	struct wifi_data *wifi = connman_device_get_data(device);
 	int ret;
 
-	if (!wifi)
+	if (!wifi || !wifi->interface)
 		return -EINVAL;
 
 	connman_device_ref(device);


### PR DESCRIPTION
Ofono may emit a signal with cellular network MCC value, resulting in
a call to wifi_set_regdom(), when the wifi_data structure has been
created but wifi->interface is still NULL. Check the pointer value
before proceeding.

The error condition is difficult to reproduce; mostly it seems to
happen when wlan tethering is active.
