### PR TITLE
[connman] refactored counters

### DIFF
--- a/connman/Makefile.am
+++ b/connman/Makefile.am
@@ -103,7 +103,7 @@ src_connmand_SOURCES = $(gdhcp_sources) $(gweb_sources) \
 			src/storage.c src/dbus.c src/config.c \
 			src/technology.c src/counter.c src/ntp.c \
 			src/session.c src/tethering.c src/wpad.c src/wispr.c \
-			src/stats.c src/iptables.c src/dnsproxy.c src/6to4.c \
+			src/stats2.c src/iptables.c src/dnsproxy.c src/6to4.c \
 			src/ippool.c src/bridge.c src/nat.c src/ipaddress.c \
 			src/inotify.c src/firewall.c src/ipv6pd.c src/peer.c
 

--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -295,6 +295,17 @@ struct connman_ipconfig_ops {
 	void (*route_unset) (struct connman_ipconfig *ipconfig, const char *ifname);
 };
 
+struct connman_stats_data {
+	uint64_t rx_packets;
+	uint64_t tx_packets;
+	uint64_t rx_bytes;
+	uint64_t tx_bytes;
+	uint64_t rx_errors;
+	uint64_t tx_errors;
+	uint64_t rx_dropped;
+	uint64_t tx_dropped;
+};
+
 struct connman_ipconfig *__connman_ipconfig_create(int index,
 					enum connman_ipconfig_type type);
 
@@ -314,6 +325,8 @@ void *__connman_ipconfig_get_data(struct connman_ipconfig *ipconfig);
 void __connman_ipconfig_set_data(struct connman_ipconfig *ipconfig, void *data);
 
 int __connman_ipconfig_get_index(struct connman_ipconfig *ipconfig);
+gboolean __connman_ipconfig_get_stats(struct connman_ipconfig *ipconfig,
+				struct connman_stats_data *stats);
 
 void __connman_ipconfig_set_ops(struct connman_ipconfig *ipconfig,
 				const struct connman_ipconfig_ops *ops);
@@ -777,10 +790,7 @@ int __connman_service_reset_ipconfig(struct connman_service *service,
 		enum connman_service_state *new_state);
 
 void __connman_service_notify(struct connman_service *service,
-			uint64_t rx_packets, uint64_t tx_packets,
-			uint64_t rx_bytes, uint64_t tx_bytes,
-			uint64_t rx_error, uint64_t tx_error,
-			uint64_t rx_dropped, uint64_t tx_dropped);
+			const struct connman_stats_data *data);
 
 int __connman_service_counter_register(const char *counter);
 void __connman_service_counter_unregister(const char *counter);
@@ -850,27 +860,21 @@ int __connman_session_destroy(DBusMessage *msg);
 int __connman_session_init(void);
 void __connman_session_cleanup(void);
 
-struct connman_stats_data {
-        uint64_t rx_packets;
-        uint64_t tx_packets;
-        uint64_t rx_bytes;
-        uint64_t tx_bytes;
-        uint64_t rx_errors;
-        uint64_t tx_errors;
-        uint64_t rx_dropped;
-        uint64_t tx_dropped;
-        unsigned int time;
-};
 
 int __connman_stats_init(void);
 void __connman_stats_cleanup(void);
-int __connman_stats_service_register(struct connman_service *service);
-void __connman_stats_service_unregister(struct connman_service *service);
-int  __connman_stats_update(struct connman_service *service,
-				bool roaming,
-				struct connman_stats_data *data);
-int __connman_stats_get(struct connman_service *service,
-				bool roaming,
+
+struct connman_stats *__connman_stats_new(const char *identifier,
+							gboolean roaming);
+struct connman_stats *__connman_stats_new_existing(const char *identifier,
+							gboolean roaming);
+void __connman_stats_free(struct connman_stats *stats);
+void __connman_stats_reset(struct connman_stats *stats);
+void __connman_stats_update(struct connman_stats *stats,
+				const struct connman_stats_data *data);
+void __connman_stats_rebase(struct connman_stats *stats,
+				const struct connman_stats_data *data);
+void __connman_stats_get(struct connman_stats *stats,
 				struct connman_stats_data *data);
 
 int __connman_iptables_dump(const char *table_name);

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -51,18 +51,22 @@ static bool services_dirty = false;
 
 int failure_connect_interval = 0;
 
-struct connman_stats {
-	bool valid;
-	bool enabled;
-	struct connman_stats_data data_last;
-	struct connman_stats_data data;
-	GTimer *timer;
+struct connman_stats_counter_data {
+	uint64_t rx_packets;
+	uint64_t tx_packets;
+	uint64_t rx_bytes;
+	uint64_t tx_bytes;
+	uint64_t rx_errors;
+	uint64_t tx_errors;
+	uint64_t rx_dropped;
+	uint64_t tx_dropped;
+	uint64_t time;
 };
 
 struct connman_stats_counter {
 	bool append_all;
-	struct connman_stats stats;
-	struct connman_stats stats_roaming;
+	struct connman_stats_counter_data stats;
+	struct connman_stats_counter_data stats_roaming;
 };
 
 struct connman_service {
@@ -111,8 +115,10 @@ struct connman_service {
 	DBusMessage *pending;
 	DBusMessage *provider_pending;
 	guint timeout;
-	struct connman_stats stats;
-	struct connman_stats stats_roaming;
+	struct connman_stats* stats;
+	struct connman_stats* stats_roaming;
+	GTimer *stats_timer;
+	uint64_t stats_update_time;
 	GHashTable *counter_table;
 	enum connman_service_proxy_method proxy;
 	enum connman_service_proxy_method proxy_config;
@@ -1295,98 +1301,57 @@ void __connman_service_nameserver_del_routes(struct connman_service *service,
 		nameserver_del_routes(index, service->nameservers, type);
 }
 
-static struct connman_stats *stats_get(struct connman_service *service)
+static struct connman_stats *stats_get_home(struct connman_service *service,
+							gboolean create)
 {
-	if (service->roaming)
-		return &service->stats_roaming;
-	else
-		return &service->stats;
+	if (!service->stats) {
+		service->stats = create ?
+			__connman_stats_new(service->identifier,false) :
+			__connman_stats_new_existing(service->identifier,false);
+
+		if (service->stats && !service->stats_timer) {
+			service->stats_timer = g_timer_new();
+			g_timer_start(service->stats_timer);
+		}
+	}
+
+	return service->stats;
 }
 
-static bool stats_enabled(struct connman_service *service)
+static struct connman_stats *stats_get_roaming(struct connman_service *service,
+							gboolean create)
 {
-	struct connman_stats *stats = stats_get(service);
+	if (!service->stats_roaming) {
+		service->stats_roaming = create ?
+			__connman_stats_new(service->identifier, true) :
+			__connman_stats_new_existing(service->identifier, true);
 
-	return stats->enabled;
+		if (service->stats_roaming && !service->stats_timer) {
+			service->stats_timer = g_timer_new();
+			g_timer_start(service->stats_timer);
+		}
+	}
+
+	return service->stats_roaming;
 }
 
-static void stats_start(struct connman_service *service)
+static struct connman_stats *stats_get(struct connman_service *service,
+							gboolean create)
 {
-	struct connman_stats *stats = stats_get(service);
+	if (!service)
+		return NULL;
 
-	DBG("service %p", service);
-
-	if (!stats->timer)
-		return;
-
-	stats->enabled = true;
-	stats->data_last.time = stats->data.time;
-
-	g_timer_start(stats->timer);
-}
-
-static void stats_stop(struct connman_service *service)
-{
-	struct connman_stats *stats = stats_get(service);
-	unsigned int seconds;
-
-	DBG("service %p", service);
-
-	if (!stats->timer)
-		return;
-
-	if (!stats->enabled)
-		return;
-
-	g_timer_stop(stats->timer);
-
-	seconds = g_timer_elapsed(stats->timer, NULL);
-	stats->data.time = stats->data_last.time + seconds;
-
-	stats->enabled = false;
+	return service->roaming ?
+		stats_get_roaming(service, create) :
+		stats_get_home(service, create);
 }
 
 static void reset_stats(struct connman_service *service)
 {
 	DBG("service %p", service);
-
-	/* home */
-	service->stats.valid = false;
-
-	service->stats.data.rx_packets = 0;
-	service->stats.data.tx_packets = 0;
-	service->stats.data.rx_bytes = 0;
-	service->stats.data.tx_bytes = 0;
-	service->stats.data.rx_errors = 0;
-	service->stats.data.tx_errors = 0;
-	service->stats.data.rx_dropped = 0;
-	service->stats.data.tx_dropped = 0;
-	service->stats.data.time = 0;
-	service->stats.data_last.time = 0;
-
-	g_timer_reset(service->stats.timer);
-
-	/* roaming */
-	service->stats_roaming.valid = false;
-
-	service->stats_roaming.data.rx_packets = 0;
-	service->stats_roaming.data.tx_packets = 0;
-	service->stats_roaming.data.rx_bytes = 0;
-	service->stats_roaming.data.tx_bytes = 0;
-	service->stats_roaming.data.rx_errors = 0;
-	service->stats_roaming.data.tx_errors = 0;
-	service->stats_roaming.data.rx_dropped = 0;
-	service->stats_roaming.data.tx_dropped = 0;
-	service->stats_roaming.data.time = 0;
-	service->stats_roaming.data_last.time = 0;
-
-	g_timer_reset(service->stats_roaming.timer);
-
-    int stats_registered = __connman_stats_service_register(service);
-    __connman_stats_update(service, false, &service->stats.data);
-    __connman_stats_update(service, true, &service->stats_roaming.data);
-    if (stats_registered == 0)
-        __connman_stats_service_unregister(service);
+	__connman_stats_reset(service->stats);
+	__connman_stats_reset(service->stats_roaming);
+	g_timer_reset(service->stats_timer);
 }
 
 struct connman_service *__connman_service_get_default(void)
@@ -2005,62 +1970,104 @@ static void link_changed(struct connman_service *service)
 }
 
 static void stats_append_counters(DBusMessageIter *dict,
-			struct connman_stats_data *stats,
-			struct connman_stats_data *counters,
+			struct connman_stats *stats,
+			uint64_t stats_time,
+			struct connman_stats_counter_data *counters,
 			bool append_all)
 {
-	if (counters->rx_packets != stats->rx_packets || append_all) {
-		counters->rx_packets = stats->rx_packets;
+	gboolean skip_time = true;
+	struct connman_stats_data data;
+
+	/* Fills data with zeros if stats is NULL */
+	__connman_stats_get(stats, &data);
+
+	if (counters->rx_packets != data.rx_packets || append_all) {
+		counters->rx_packets = data.rx_packets;
 		connman_dbus_dict_append_basic(dict, "RX.Packets",
-					DBUS_TYPE_UINT64, &stats->rx_packets);
+					DBUS_TYPE_UINT64, &data.rx_packets);
+		skip_time = false;
 	}
 
-	if (counters->tx_packets != stats->tx_packets || append_all) {
-		counters->tx_packets = stats->tx_packets;
+	if (counters->tx_packets != data.tx_packets || append_all) {
+		counters->tx_packets = data.tx_packets;
 		connman_dbus_dict_append_basic(dict, "TX.Packets",
-					DBUS_TYPE_UINT64, &stats->tx_packets);
+					DBUS_TYPE_UINT64, &data.tx_packets);
+		skip_time = false;
 	}
 
-	if (counters->rx_bytes != stats->rx_bytes || append_all) {
-		counters->rx_bytes = stats->rx_bytes;
+	if (counters->rx_bytes != data.rx_bytes || append_all) {
+		counters->rx_bytes = data.rx_bytes;
 		connman_dbus_dict_append_basic(dict, "RX.Bytes",
-					DBUS_TYPE_UINT64, &stats->rx_bytes);
+					DBUS_TYPE_UINT64, &data.rx_bytes);
+		skip_time = false;
 	}
 
-	if (counters->tx_bytes != stats->tx_bytes || append_all) {
-		counters->tx_bytes = stats->tx_bytes;
+	if (counters->tx_bytes != data.tx_bytes || append_all) {
+		counters->tx_bytes = data.tx_bytes;
 		connman_dbus_dict_append_basic(dict, "TX.Bytes",
-					DBUS_TYPE_UINT64, &stats->tx_bytes);
+					DBUS_TYPE_UINT64, &data.tx_bytes);
+		skip_time = false;
 	}
 
-	if (counters->rx_errors != stats->rx_errors || append_all) {
-		counters->rx_errors = stats->rx_errors;
+	if (counters->rx_errors != data.rx_errors || append_all) {
+		counters->rx_errors = data.rx_errors;
 		connman_dbus_dict_append_basic(dict, "RX.Errors",
-					DBUS_TYPE_UINT64, &stats->rx_errors);
+					DBUS_TYPE_UINT64, &data.rx_errors);
+		skip_time = false;
 	}
 
-	if (counters->tx_errors != stats->tx_errors || append_all) {
-		counters->tx_errors = stats->tx_errors;
+	if (counters->tx_errors != data.tx_errors || append_all) {
+		counters->tx_errors = data.tx_errors;
 		connman_dbus_dict_append_basic(dict, "TX.Errors",
-					DBUS_TYPE_UINT64, &stats->tx_errors);
+					DBUS_TYPE_UINT64, &data.tx_errors);
+		skip_time = false;
 	}
 
-	if (counters->rx_dropped != stats->rx_dropped || append_all) {
-		counters->rx_dropped = stats->rx_dropped;
+	if (counters->rx_dropped != data.rx_dropped || append_all) {
+		counters->rx_dropped = data.rx_dropped;
 		connman_dbus_dict_append_basic(dict, "RX.Dropped",
-					DBUS_TYPE_UINT64, &stats->rx_dropped);
+					DBUS_TYPE_UINT64, &data.rx_dropped);
+		skip_time = false;
 	}
 
-	if (counters->tx_dropped != stats->tx_dropped || append_all) {
-		counters->tx_dropped = stats->tx_dropped;
+	if (counters->tx_dropped != data.tx_dropped || append_all) {
+		counters->tx_dropped = data.tx_dropped;
 		connman_dbus_dict_append_basic(dict, "TX.Dropped",
-					DBUS_TYPE_UINT64, &stats->tx_dropped);
+					DBUS_TYPE_UINT64, &data.tx_dropped);
+		skip_time = false;
 	}
 
-	if (counters->time != stats->time || append_all) {
-		counters->time = stats->time;
+	if (!skip_time && (counters->time != stats_time || append_all)) {
+		counters->time = stats_time;
 		connman_dbus_dict_append_basic(dict, "Time",
-					DBUS_TYPE_UINT64, &stats->time);
+					DBUS_TYPE_UINT64, &stats_time);
+	}
+}
+
+static void stats_append_saved_counters(DBusMessageIter *dict,
+				const char *identifier, gboolean roaming)
+{
+	struct connman_stats *stats;
+	struct connman_stats_counter_data counters;
+	bzero(&counters, sizeof(counters));
+
+	/* Both stats_append_counters() and __connman_stats_free() handle
+	 * NULL stats, no need to check __connman_stats_new_existing()
+	 * return value. */
+	stats = __connman_stats_new_existing(identifier, roaming);
+	stats_append_counters(dict, stats, 0, &counters, true);
+	__connman_stats_free(stats);
+}
+
+static void stats_reset_saved_counters(const char *identifier, gboolean roaming)
+{
+	struct connman_stats *stats;
+
+	/* Nothing tyo reset if file doesn't exist */
+	stats = __connman_stats_new_existing(identifier, roaming);
+	if (stats) {
+		__connman_stats_reset(stats);
+		__connman_stats_free(stats);
 	}
 }
 
@@ -2086,81 +2093,30 @@ static void stats_append(struct connman_service *service,
 	/* home counter */
 	connman_dbus_dict_open(&array, &dict);
 
-	stats_append_counters(&dict, &service->stats.data,
-				&counters->stats.data, append_all);
+	stats_append_counters(&dict, service->stats,
+		service->stats_update_time, &counters->stats,
+		append_all);
 
 	connman_dbus_dict_close(&array, &dict);
 
 	/* roaming counter */
 	connman_dbus_dict_open(&array, &dict);
 
-	stats_append_counters(&dict, &service->stats_roaming.data,
-				&counters->stats_roaming.data, append_all);
+	stats_append_counters(&dict, service->stats_roaming,
+		service->stats_update_time, &counters->stats_roaming,
+		append_all);
 
 	connman_dbus_dict_close(&array, &dict);
 
 	__connman_counter_send_usage(counter, msg);
 }
 
-static void stats_update(struct connman_service *service,
-				uint64_t rx_packets, uint64_t tx_packets,
-				uint64_t rx_bytes, uint64_t tx_bytes,
-				uint64_t rx_errors, uint64_t tx_errors,
-				uint64_t rx_dropped, uint64_t tx_dropped)
-{
-	struct connman_stats *stats = stats_get(service);
-	struct connman_stats_data *data_last = &stats->data_last;
-	struct connman_stats_data *data = &stats->data;
-	unsigned int seconds;
-
-	DBG("service %p", service);
-
-	if (stats->valid) {
-		data->rx_packets +=
-			rx_packets - data_last->rx_packets;
-		data->tx_packets +=
-			tx_packets - data_last->tx_packets;
-		data->rx_bytes +=
-			rx_bytes - data_last->rx_bytes;
-		data->tx_bytes +=
-			tx_bytes - data_last->tx_bytes;
-		data->rx_errors +=
-			rx_errors - data_last->rx_errors;
-		data->tx_errors +=
-			tx_errors - data_last->tx_errors;
-		data->rx_dropped +=
-			rx_dropped - data_last->rx_dropped;
-		data->tx_dropped +=
-			tx_dropped - data_last->tx_dropped;
-	} else {
-		stats->valid = true;
-	}
-
-	data_last->rx_packets = rx_packets;
-	data_last->tx_packets = tx_packets;
-	data_last->rx_bytes = rx_bytes;
-	data_last->tx_bytes = tx_bytes;
-	data_last->rx_errors = rx_errors;
-	data_last->tx_errors = tx_errors;
-	data_last->rx_dropped = rx_dropped;
-	data_last->tx_dropped = tx_dropped;
-
-	seconds = g_timer_elapsed(stats->timer, NULL);
-	stats->data.time = stats->data_last.time + seconds;
-}
-
 void __connman_service_notify(struct connman_service *service,
-			uint64_t rx_packets, uint64_t tx_packets,
-			uint64_t rx_bytes, uint64_t tx_bytes,
-			uint64_t rx_errors, uint64_t tx_errors,
-			uint64_t rx_dropped, uint64_t tx_dropped)
+			const struct connman_stats_data *data)
 {
 	GHashTableIter iter;
 	gpointer key, value;
-	const char *counter;
-	struct connman_stats_counter *counters;
-	struct connman_stats_data *data;
-	int err;
+	struct connman_stats *stats;
 
 	if (!service)
 		return;
@@ -2168,22 +2124,16 @@ void __connman_service_notify(struct connman_service *service,
 	if (!is_connected(service))
 		return;
 
-	stats_update(service,
-		rx_packets, tx_packets,
-		rx_bytes, tx_bytes,
-		rx_errors, tx_errors,
-		rx_dropped, tx_dropped);
+	DBG("service %p", service);
 
-	data = &stats_get(service)->data;
-	err = __connman_stats_update(service, service->roaming, data);
-	if (err < 0)
-		connman_error("Failed to store statistics for %s",
-				service->identifier);
+	stats = stats_get(service, true);
+	service->stats_update_time = g_timer_elapsed(service->stats_timer, 0);
+	__connman_stats_update(stats, data);
 
 	g_hash_table_iter_init(&iter, service->counter_table);
 	while (g_hash_table_iter_next(&iter, &key, &value)) {
-		counter = key;
-		counters = value;
+		const char *counter = key;
+		struct connman_stats_counter *counters = value;
 
 		stats_append(service, counter, counters, counters->append_all);
 		counters->append_all = false;
@@ -2217,117 +2167,74 @@ int __connman_service_counter_register(const char *counter)
 }
 
 
-static void __connman_service_counter_append_saved(const char *counter, const char *identifier)
+static void __connman_service_counter_append_saved(const char *counter,
+							const char *identifier)
 {
-    // Ignore saved cellular services. Only report usage for the currently active SIM
-    if (strncmp(identifier, "cellular_", 9) == 0)
-        return;
+	char* path;
+	DBusMessage *msg;
+	DBusMessageIter array;
+	DBusMessageIter dict;
 
-    struct connman_service *service = connman_service_create();
-    if (service == NULL)
-        return;
+	/* Ignore saved cellular services. Only report usage for the
+	 * currently active SIM */
+	if (strncmp(identifier, "cellular_", 9) == 0)
+		return;
 
-    service->identifier = g_strdup(identifier);
-    service->path = g_strdup_printf("%s/service/%s", CONNMAN_PATH, service->identifier);
+	msg = dbus_message_new(DBUS_MESSAGE_TYPE_METHOD_CALL);
+	if (!msg)
+		return;
 
-    DBusMessage *msg = dbus_message_new(DBUS_MESSAGE_TYPE_METHOD_CALL);
-    if (msg == NULL) {
-        service_destroy(service);
-        return;
-    }
+	path = g_strconcat(CONNMAN_PATH "/service/", identifier, NULL);
+	dbus_message_append_args(msg, DBUS_TYPE_OBJECT_PATH, &path,
+							DBUS_TYPE_INVALID);
+	dbus_message_iter_init_append(msg, &array);
 
-    __connman_stats_service_register(service);
+	/* Home counter */
+	connman_dbus_dict_open(&array, &dict);
+	stats_append_saved_counters(&dict, identifier, false);
+	connman_dbus_dict_close(&array, &dict);
 
-    dbus_message_append_args(msg, DBUS_TYPE_OBJECT_PATH, &service->path, DBUS_TYPE_INVALID);
+	/* Roaming counter */
+	connman_dbus_dict_open(&array, &dict);
+	stats_append_saved_counters(&dict, identifier, true);
+	connman_dbus_dict_close(&array, &dict);
 
-    DBusMessageIter array;
-    DBusMessageIter dict;
-
-    dbus_message_iter_init_append(msg, &array);
-
-    struct connman_stats_data data;
-
-    // home counter
-    connman_dbus_dict_open(&array, &dict);
-
-    bzero(&data, sizeof(data));
-    if (__connman_stats_get(service, FALSE, &data) == 0)
-        stats_append_counters(&dict, &data, &data, TRUE);
-
-    connman_dbus_dict_close(&array, &dict);
-
-    // roaming counter
-    connman_dbus_dict_open(&array, &dict);
-
-    bzero(&data, sizeof(data));
-    if (__connman_stats_get(service, TRUE, &data) == 0)
-        stats_append_counters(&dict, &data, &data, TRUE);
-
-    connman_dbus_dict_close(&array, &dict);
-
-    __connman_counter_send_usage(counter, msg);
-
-    __connman_stats_service_unregister(service);
-
-    service_destroy(service);
+	__connman_counter_send_usage(counter, msg);
+	g_free(path);
 }
 
-static void __connman_service_counter_append(const char *counter, struct connman_service *service)
+static void __connman_service_counter_append(const char *counter,
+					struct connman_service *service)
 {
-    DBusMessage *msg = dbus_message_new(DBUS_MESSAGE_TYPE_METHOD_CALL);
-    if (msg == NULL)
-        return;
+	struct connman_stats *stats;
+	struct connman_stats_counter_data data;
+	DBusMessageIter array;
+	DBusMessageIter dict;
+	DBusMessage *msg = dbus_message_new(DBUS_MESSAGE_TYPE_METHOD_CALL);
+	uint64_t t = service->stats_update_time;
 
-    dbus_message_append_args(msg, DBUS_TYPE_OBJECT_PATH, &service->path, DBUS_TYPE_INVALID);
+	if (msg == NULL)
+		return;
 
-    DBusMessageIter array;
-    DBusMessageIter dict;
+	dbus_message_append_args(msg, DBUS_TYPE_OBJECT_PATH, &service->path,
+							DBUS_TYPE_INVALID);
+	dbus_message_iter_init_append(msg, &array);
 
-    dbus_message_iter_init_append(msg, &array);
+	/* Home counter */
+	connman_dbus_dict_open(&array, &dict);
+	stats = stats_get_home(service, false);
+	bzero(&data, sizeof(data));
+	stats_append_counters(&dict, stats, t, &data, true);
+	connman_dbus_dict_close(&array, &dict);
 
-    struct connman_stats_data data;
+	/* Roaming counter */
+	connman_dbus_dict_open(&array, &dict);
+	stats = stats_get_roaming(service, false);
+	bzero(&data, sizeof(data));
+	stats_append_counters(&dict, stats, t, &data, true);
+	connman_dbus_dict_close(&array, &dict);
 
-    bzero(&data, sizeof(data));
-    if (__connman_stats_get(service, FALSE, &data) == 0) {
-        // Stats already loaded
-
-        // home counter
-        connman_dbus_dict_open(&array, &dict);
-        stats_append_counters(&dict, &data, &data, TRUE);
-        connman_dbus_dict_close(&array, &dict);
-
-        // roaming counter
-        connman_dbus_dict_open(&array, &dict);
-
-        bzero(&data, sizeof(data));
-        if (__connman_stats_get(service, TRUE, &data) == 0)
-            stats_append_counters(&dict, &data, &data, TRUE);
-
-        connman_dbus_dict_close(&array, &dict);
-    } else {
-        __connman_stats_service_register(service);
-
-        // home counter
-        connman_dbus_dict_open(&array, &dict);
-
-        if (__connman_stats_get(service, FALSE, &data) == 0)
-            stats_append_counters(&dict, &data, &data, TRUE);
-
-        connman_dbus_dict_close(&array, &dict);
-
-        // roaming counter
-        connman_dbus_dict_open(&array, &dict);
-
-        bzero(&data, sizeof(data));
-        if (__connman_stats_get(service, TRUE, &data) == 0)
-            stats_append_counters(&dict, &data, &data, TRUE);
-
-        connman_dbus_dict_close(&array, &dict);
-
-        __connman_stats_service_unregister(service);
-    }
-
-    __connman_counter_send_usage(counter, msg);
+	__connman_counter_send_usage(counter, msg);
 }
 
 void __connman_service_counter_send_initial(const char *counter)
@@ -2354,24 +2261,8 @@ void __connman_service_counter_send_initial(const char *counter)
 
 static void __connman_service_counter_reset_saved(const char *identifier)
 {
-    struct connman_service *service = connman_service_create();
-    if (service == NULL)
-        return;
-
-    service->identifier = g_strdup(identifier);
-    service->path = g_strdup_printf("%s/service/%s", CONNMAN_PATH, service->identifier);
-
-    __connman_stats_service_register(service);
-
-    struct connman_stats_data data;
-    bzero(&data, sizeof(data));
-
-    __connman_stats_update(service, FALSE, &data);
-    __connman_stats_update(service, TRUE, &data);
-
-    __connman_stats_service_unregister(service);
-
-    service_destroy(service);
+	stats_reset_saved_counters(identifier, true);
+	stats_reset_saved_counters(identifier, false);
 }
 
 void __connman_service_counter_reset_all(const char *type)
@@ -4228,8 +4119,6 @@ static gboolean connect_timeout(gpointer user_data)
 	__connman_ipconfig_disable(service->ipconfig_ipv4);
 	__connman_ipconfig_disable(service->ipconfig_ipv6);
 
-	__connman_stats_service_unregister(service);
-
 	if (service->pending) {
 		DBusMessage *reply;
 
@@ -4795,6 +4684,14 @@ static const GDBusSignalTable service_signals[] = {
 	{ },
 };
 
+static void stats_destroy(struct connman_service *service)
+{
+	__connman_stats_free(service->stats);
+	__connman_stats_free(service->stats_roaming);
+	if (service->stats_timer)
+		g_timer_destroy(service->stats_timer);
+}
+
 static void service_destroy(struct connman_service *service)
 {
         if (service->path != NULL)
@@ -4850,10 +4747,7 @@ static void service_destroy(struct connman_service *service)
         g_free(service->config_file);
         g_free(service->config_entry);
 
-        if (service->stats.timer != NULL)
-                g_timer_destroy(service->stats.timer);
-        if (service->stats_roaming.timer != NULL)
-                g_timer_destroy(service->stats_roaming.timer);
+        stats_destroy(service);
 
         g_free(service);
 }
@@ -4871,7 +4765,6 @@ static void service_free(gpointer user_data)
 	service_schedule_removed(service);
 
 	__connman_wispr_stop(service);
-	stats_stop(service);
 
 	service->path = NULL;
 
@@ -4934,10 +4827,7 @@ static void service_free(gpointer user_data)
 	g_free(service->config_file);
 	g_free(service->config_entry);
 
-	if (service->stats.timer)
-		g_timer_destroy(service->stats.timer);
-	if (service->stats_roaming.timer)
-		g_timer_destroy(service->stats_roaming.timer);
+	stats_destroy(service);
 
 	if (current_default == service)
 		current_default = NULL;
@@ -4946,19 +4836,6 @@ static void service_free(gpointer user_data)
 		g_source_remove(service->online_check_timer);
 
 	g_free(service);
-}
-
-static void stats_init(struct connman_service *service)
-{
-	/* home */
-	service->stats.valid = false;
-	service->stats.enabled = false;
-	service->stats.timer = g_timer_new();
-
-	/* roaming */
-	service->stats_roaming.valid = false;
-	service->stats_roaming.enabled = false;
-	service->stats_roaming.timer = g_timer_new();
 }
 
 static void service_initialize(struct connman_service *service)
@@ -4985,8 +4862,6 @@ static void service_initialize(struct connman_service *service)
 	service->connect_reason = CONNMAN_SERVICE_CONNECT_REASON_NONE;
 
 	service->order = 0;
-
-	stats_init(service);
 
 	service->provider = NULL;
 
@@ -5782,35 +5657,8 @@ static int service_indicate_state(struct connman_service *service)
 		__connman_service_disconnect(service);
 	}
 
-	if (new_state == CONNMAN_SERVICE_STATE_CONFIGURATION) {
-		if (!service->new_service &&
-				__connman_stats_service_register(service) == 0) {
-			/*
-			 * For new services the statistics are updated after
-			 * we have successfully connected.
-			 */
-			__connman_stats_get(service, false,
-						&service->stats.data);
-			__connman_stats_get(service, true,
-						&service->stats_roaming.data);
-		}
-	}
-
 	if (new_state == CONNMAN_SERVICE_STATE_READY) {
 		enum connman_ipconfig_method method;
-
-		if (service->new_service &&
-				__connman_stats_service_register(service) == 0) {
-			/*
-			 * This is normally done after configuring state
-			 * but for new service do this after we have connected
-			 * successfully.
-			 */
-			__connman_stats_get(service, false,
-						&service->stats.data);
-			__connman_stats_get(service, true,
-						&service->stats_roaming.data);
-		}
 
 		service->new_service = false;
 
@@ -6399,13 +6247,6 @@ static int service_connect(struct connman_service *service)
 			break;
 		}
 
-		if (__connman_stats_service_register(service) == 0) {
-			__connman_stats_get(service, false,
-						&service->stats.data);
-			__connman_stats_get(service, true,
-						&service->stats_roaming.data);
-		}
-
 		if (service->ipconfig_ipv4)
 			__connman_ipconfig_enable(service->ipconfig_ipv4);
 		if (service->ipconfig_ipv6)
@@ -6422,7 +6263,6 @@ static int service_connect(struct connman_service *service)
 		if (err != -EINPROGRESS) {
 			__connman_ipconfig_disable(service->ipconfig_ipv4);
 			__connman_ipconfig_disable(service->ipconfig_ipv6);
-			__connman_stats_service_unregister(service);
 		}
 	}
 
@@ -6553,8 +6393,6 @@ int __connman_service_disconnect(struct connman_service *service)
 
 	__connman_ipconfig_disable(service->ipconfig_ipv4);
 	__connman_ipconfig_disable(service->ipconfig_ipv6);
-
-	__connman_stats_service_unregister(service);
 
 	return err;
 }
@@ -6723,9 +6561,6 @@ static void service_up(struct connman_ipconfig *ipconfig,
 	DBG("%s up", ifname);
 
 	link_changed(service);
-
-	service->stats.valid = false;
-	service->stats_roaming.valid = false;
 }
 
 static void service_down(struct connman_ipconfig *ipconfig,
@@ -6738,10 +6573,11 @@ static void service_lower_up(struct connman_ipconfig *ipconfig,
 			const char *ifname)
 {
 	struct connman_service *service = __connman_ipconfig_get_data(ipconfig);
+	struct connman_stats_data data;
 
 	DBG("%s lower up", ifname);
-
-	stats_start(service);
+	if (__connman_ipconfig_get_stats(ipconfig, &data))
+		__connman_stats_rebase(stats_get(service, true), &data);
 }
 
 static void service_lower_down(struct connman_ipconfig *ipconfig,
@@ -6757,7 +6593,6 @@ static void service_lower_down(struct connman_ipconfig *ipconfig,
 	if (!is_idle_state(service, service->state_ipv6))
 		__connman_ipconfig_disable(service->ipconfig_ipv6);
 
-	stats_stop(service);
 	service_save(service);
 }
 
@@ -7248,7 +7083,6 @@ void __connman_service_update_from_network(struct connman_network *network)
 	uint8_t strength;
 	bool roaming;
 	const char *name;
-	bool stats_enable;
 
 	service = connman_service_lookup_from_network(network);
 	if (!service)
@@ -7285,15 +7119,8 @@ roaming:
 	if (roaming == service->roaming)
 		goto sorting;
 
-	stats_enable = stats_enabled(service);
-	if (stats_enable)
-		stats_stop(service);
-
 	service->roaming = roaming;
 	need_sort = true;
-
-	if (stats_enable)
-		stats_start(service);
 
 	roaming_changed(service);
 

--- a/connman/src/stats2.c
+++ b/connman/src/stats2.c
@@ -1,0 +1,288 @@
+/*
+ *
+ *  Connection Manager
+ *
+ *  Copyright (C) 2014 Jolla Ltd. All rights reserved.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+#include "connman.h"
+
+/*
+ * Simplified version of stats.c
+ */
+
+#define STATS_DIR_MODE      (0755)
+#define STATS_FILE_MODE     (0644)
+#define STATS_FILE_VERSION  (0x01)
+#define STATS_FILE_SIZE     sizeof(struct stats_file_contents)
+#define STATS_FILE_HOME     "stats.home"
+#define STATS_FILE_ROAMING  "stats.roaming"
+
+#define stats_file(roaming) ((roaming) ? STATS_FILE_ROAMING : STATS_FILE_HOME)
+
+/* Unused files that may have been created by earlier versions of connman */
+static const char* stats_obsolete[] = { "data", "history" };
+
+struct stats_file_contents {
+	uint32_t version;
+	uint32_t reserved;
+	struct connman_stats_data total;
+} __attribute__((packed));
+
+struct connman_stats {
+	int fd;
+	char *path;
+	char *name;
+	struct stats_file_contents *contents;
+	struct connman_stats_data last;
+};
+
+static void stats_init_contents(struct connman_stats *stats)
+{
+	if (stats->contents->version != STATS_FILE_VERSION) {
+		DBG("%s", stats->name);
+		memset(stats->contents, 0, STATS_FILE_SIZE);
+		stats->contents->version = STATS_FILE_VERSION;
+	}
+}
+
+static struct connman_stats *stats_file_open(const char *id, const char *dir,
+					const char *file, gboolean create)
+{
+        const int flags = O_RDWR | O_CLOEXEC | (create ? O_CREAT : 0);
+	char* path = g_strconcat(dir, "/", file, NULL);
+	int fd = open(path, flags, STATS_FILE_MODE);
+	if (fd >= 0) {
+		int err = ftruncate(fd, STATS_FILE_SIZE);
+		if (err >= 0) {
+			struct connman_stats *stats;
+
+			stats = g_new0(struct connman_stats, 1);
+			stats->contents = mmap(NULL, STATS_FILE_SIZE,
+				PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+			if (stats->contents != MAP_FAILED) {
+				/* Success */
+				DBG("%s", path);
+				DBG("[RX] %llu packets %llu bytes",
+					stats->contents->total.rx_packets,
+					stats->contents->total.rx_bytes);
+				DBG("[TX] %llu packets %llu bytes",
+					stats->contents->total.tx_packets,
+					stats->contents->total.tx_bytes);
+
+				stats->fd = fd;
+				stats->path = path;
+				stats->name = g_strconcat(id, "/", file, NULL);
+				stats_init_contents(stats);
+				return stats;
+			}
+			connman_error("mmap %s error: %s", path,
+				strerror(errno));
+			g_free(stats);
+		} else {
+			connman_error("ftrunctate %s error: %s", path,
+				strerror(errno));
+		}
+		close(fd);
+	}
+	/* Error */
+	g_free(path);
+	return NULL;
+}
+
+/** Deletes the leftovers from the old connman */
+static void stats_delete_obsolete_files(const char* dir)
+{
+	int i;
+	for (i=0; i<G_N_ELEMENTS(stats_obsolete); i++) {
+		char* path = g_strconcat(dir, "/", stats_obsolete[i], NULL);
+		if (unlink(path) < 0) {
+			if (errno != ENOENT) {
+				connman_error("error deleting %s: %s",
+						path, strerror(errno));
+			}
+		} else {
+			DBG("deleted %s", path);
+		}
+		g_free(path);
+	}
+}
+
+/** Creates file if it doesn't exist */
+struct connman_stats *__connman_stats_new(const char *ident, gboolean roaming)
+{
+	int err = 0;
+	struct connman_stats *stats = NULL;
+	char *dir = g_strconcat(STORAGEDIR, "/", ident, NULL);
+
+	DBG("%s %d", ident, roaming);
+
+	/* If the dir doesn't exist, create it */
+	if (!g_file_test(dir, G_FILE_TEST_IS_DIR)) {
+		if (mkdir(dir, STATS_DIR_MODE) < 0) {
+			if (errno != EEXIST) {
+				err = -errno;
+			}
+		}
+	}
+
+	if (!err) {
+		stats = stats_file_open(ident, dir, stats_file(roaming), true);
+		stats_delete_obsolete_files(dir);
+	} else {
+		connman_error("failed to create %s: %s", dir, strerror(errno));
+	}
+
+	g_free(dir);
+	return stats;
+}
+
+/** Returns NULL if the file doesn't exist */
+struct connman_stats *__connman_stats_new_existing(const char *identifier,
+							gboolean roaming)
+{
+	char *dir = g_strconcat(STORAGEDIR, "/", identifier, NULL);
+	struct connman_stats *stats;
+
+	stats = stats_file_open(identifier, dir, stats_file(roaming), false);
+	g_free(dir);
+	return stats;
+}
+
+void __connman_stats_free(struct connman_stats *stats)
+{
+	if (stats) {
+		DBG("%s", stats->name);
+		msync(stats->contents, STATS_FILE_SIZE, MS_SYNC);
+		munmap(stats->contents, STATS_FILE_SIZE);
+		close(stats->fd);
+		g_free(stats->path);
+		g_free(stats->name);
+		g_free(stats);
+	}
+}
+
+void __connman_stats_update(struct connman_stats *stats,
+				const struct connman_stats_data *data)
+{
+	struct connman_stats_data* last;
+
+	if (!stats)
+		return;
+
+	last = &stats->last;
+
+	/* If nothing has changed, avoid overwriting the last data
+	 * to reduce the number of writes to the file */
+	if (!memcmp(last, data, sizeof(*last)))
+		return;
+
+	DBG("%s [RX] %llu packets %llu bytes", stats->name,
+					data->rx_packets, data->rx_bytes);
+	DBG("%s [TX] %llu packets %llu bytes", stats->name,
+					data->tx_packets, data->tx_bytes);
+
+	if (data->rx_packets < last->rx_packets ||
+	    data->tx_packets < last->tx_packets ||
+	    data->rx_bytes   < last->rx_bytes   ||
+	    data->tx_bytes   < last->tx_bytes   ||
+	    data->rx_errors  < last->rx_errors  ||
+	    data->tx_errors  < last->tx_errors  ||
+	    data->rx_dropped < last->rx_dropped ||
+	    data->tx_dropped < last->tx_dropped) {
+
+		/* This can happen if the counter wasn't rebased after
+		 * switching the network interface. In a perfect world
+		 * that should never happen of course */
+		DBG("%s screwed up", stats->name);
+
+	} else {
+
+		/* Update the total counters, remember the last values */
+		struct connman_stats_data* total = &stats->contents->total;
+
+		total->rx_packets += (data->rx_packets - last->rx_packets);
+		total->tx_packets += (data->tx_packets - last->tx_packets);
+		total->rx_bytes   += (data->rx_bytes   - last->rx_bytes  );
+		total->tx_bytes   += (data->tx_bytes   - last->tx_bytes  );
+		total->rx_errors  += (data->rx_errors  - last->rx_errors );
+		total->tx_errors  += (data->tx_errors  - last->tx_errors );
+		total->rx_dropped += (data->rx_dropped - last->rx_dropped);
+		total->tx_dropped += (data->tx_dropped - last->tx_dropped);
+	}
+
+	*last = *data;
+}
+
+void __connman_stats_reset(struct connman_stats *stats)
+{
+	if (stats) {
+		struct connman_stats_data* total = &stats->contents->total;
+
+		DBG("%s", stats->name);
+		memset(total, 0, sizeof(*total));
+	}
+}
+
+void __connman_stats_rebase(struct connman_stats *stats,
+				const struct connman_stats_data *data)
+{
+	if (stats) {
+		struct connman_stats_data* last = &stats->last;
+
+		if (data) {
+			DBG("%s [RX] %llu packets %llu bytes", stats->name,
+					data->rx_packets, data->rx_bytes);
+			DBG("%s [TX] %llu packets %llu bytes", stats->name,
+					data->tx_packets, data->tx_bytes);
+			*last = *data;
+		} else {
+			DBG("%s", stats->name);
+			memset(last, 0, sizeof(*last));
+		}
+	}
+}
+
+void __connman_stats_get(struct connman_stats *stats,
+				struct connman_stats_data *data)
+{
+	if (stats) {
+		*data = stats->contents->total;
+	} else {
+		bzero(data, sizeof(*data));
+	}
+}
+
+int __connman_stats_init(void)
+{
+	return 0;
+}
+
+void __connman_stats_cleanup(void)
+{
+}


### PR DESCRIPTION
1. Replaced stats.c with stats2.c which isn't doing anything we don't need. The new implementation is much smaller and simpler. It also eliminates the global hashtable which served the purpose of associating service with stats - now it's done using a pointer. Roaming and home statistics are separated from each other.
2. Fixed the problem with service being notified about the counter changes for a wrong interface. The cellular service may be associated with different interfaces over time. In practice it's ether rmnet0 or rmnet1, depending on MMS context activity and whether or not one of those interfaces was up when connman started (when it crashes, ofono interfaces stay up).
