### PR TITLE
[connman] Don't override user setting when setting auto proxy url via dh...

### DIFF
--- a/connman/src/dhcp.c
+++ b/connman/src/dhcp.c
@@ -104,7 +104,7 @@ static void dhcp_invalidate(struct connman_dhcp *dhcp, bool callback)
 	__connman_6to4_remove(ipconfig);
 
 	__connman_service_set_domainname(service, NULL);
-	__connman_service_set_pac(service, NULL);
+	__connman_ipconfig_set_proxy_autoconfig(ipconfig, NULL);
 
 	if (dhcp->timeservers) {
 		for (i = 0; dhcp->timeservers[i]; i++) {
@@ -445,7 +445,7 @@ static void lease_available_cb(GDHCPClient *dhcp_client, gpointer user_data)
 		g_free(dhcp->pac);
 		dhcp->pac = pac;
 
-		__connman_service_set_pac(service, dhcp->pac);
+		__connman_ipconfig_set_proxy_autoconfig(ipconfig, dhcp->pac);
 	}
 
 	if (ip_change)


### PR DESCRIPTION
...cp.

Fixes loss of proxy auto configuration settings on first connect after
reboot or when a DHCP lease is renewed.

The pac field is used to store the user set proxy auto configuration
URL (from Proxy.Configuration property). DHCP was using the same field
instead of the proxy auto configuration field in the IP configuration
structure.
