### PR TITLE
service: cancel agent requests prior to deleting wispr context

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -6522,7 +6522,7 @@ int __connman_service_disconnect(struct connman_service *service)
 	service->connect_reason = CONNMAN_SERVICE_CONNECT_REASON_NONE;
 	service->proxy = CONNMAN_SERVICE_PROXY_METHOD_UNKNOWN;
 
-	connman_agent_cancel(service);
+	__connman_wispr_stop(service);
 
 	reply_pending(service, ECONNABORTED);
 

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -29,6 +29,7 @@
 #include <gweb/gweb.h>
 
 #include "connman.h"
+#include "agent.h"
 
 struct connman_wispr_message {
 	bool has_error;
@@ -974,6 +975,7 @@ void __connman_wispr_stop(struct connman_service *service)
 	if (index < 0)
 		return;
 
+	connman_agent_cancel(service);
 	g_hash_table_remove(wispr_portal_list, GINT_TO_POINTER(index));
 }
 


### PR DESCRIPTION
Calling __connman_wispr_stop() without connman_agent_cancel() allows pending wispr requests to complete later which results in a read/write access to the freed memory and a subsequent crash.

Calling connman_agent_cancel() without __connman_wispr_stop() stops the wispr sequence which renders the wispr context useless. That makes no sense either.
