### PR TITLE
service: mark mobile data connection as "auto"

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -4319,8 +4319,13 @@ static DBusMessage *connect_service(DBusConnection *conn,
 
 	failure_connect_interval = 0;
 
+	/* mobile data connections forced by connectionagent should
+	 * be considered "auto" connections, otherwise mobile data
+	 * interface remains active after switching to wifi */
 	err = __connman_service_connect(service,
-			CONNMAN_SERVICE_CONNECT_REASON_USER);
+			(service->type == CONNMAN_SERVICE_TYPE_CELLULAR) ?
+				CONNMAN_SERVICE_CONNECT_REASON_AUTO :
+				CONNMAN_SERVICE_CONNECT_REASON_USER);
 
 	if (err == -EINPROGRESS)
 		return NULL;


### PR DESCRIPTION
When connectionagent "helps" connman to switch to mobile data, such connection was treated by connman as a "user" connection. That interferes with the connman's auto-connection logic. Particularly, the "user" connections are not automatically brought down - connman seems to expect the "user" who established the connection to bring it down when the connection is no longer needed. Which connectionagent never does, so mobile context never gets deactivated. Occasionally, some data is still transferred over mobile data connection even if wifi is up and operational. That's not a kind of behavior the user would expect, especially if he/she is being charged for the mobile data traffic.

This counter-hack allows connman to apply its auto-disconnect logic to the mobile data interface activated by connectionagent.
