### PR TITLE
[connman] change all connman_info to DBG

### DIFF
--- a/connman/plugins/loopback.c
+++ b/connman/plugins/loopback.c
@@ -69,7 +69,7 @@ static int setup_hostname(void)
 
 	if (strlen(system_hostname) > 0 &&
 				strcmp(system_hostname, "(none)") != 0)
-		connman_info("System hostname is %s", system_hostname);
+		DBG("System hostname is %s", system_hostname);
 	else
 		create_hostname();
 
@@ -81,7 +81,7 @@ static int setup_hostname(void)
 	}
 
 	if (strlen(name) > 0 && strcmp(name, "(none)") != 0)
-		connman_info("System domainname is %s", name);
+		DBG("System domainname is %s", name);
 
 	return 0;
 }
@@ -147,7 +147,7 @@ static int setup_loopback(void)
 	}
 
 	if (ifr.ifr_flags & IFF_UP) {
-		connman_info("Checking loopback interface settings");
+		DBG("Checking loopback interface settings");
 		if (valid_loopback(sk, &ifr)) {
 			err = -EALREADY;
 			goto done;
@@ -227,7 +227,7 @@ static int loopback_set_hostname(const char *hostname)
 		return err;
 	}
 
-	connman_info("Setting hostname to %s", hostname);
+	DBG("Setting hostname to %s", hostname);
 
 	return 0;
 }
@@ -247,7 +247,7 @@ static int loopback_set_domainname(const char *domainname)
 		return err;
 	}
 
-	connman_info("Setting domainname to %s", domainname);
+	DBG("Setting domainname to %s", domainname);
 
 	return 0;
 }

--- a/connman/plugins/session_policy_local.c
+++ b/connman/plugins/session_policy_local.c
@@ -719,7 +719,7 @@ static void notify_handler(struct inotify_event *event,
 		return;
 
 	if (event->mask & (IN_MOVED_TO | IN_MODIFY)) {
-		connman_info("Policy update for '%s'", filename);
+		DBG("Policy update for '%s'", filename);
 
 		file = g_new0(struct policy_file, 1);
 		if (load_file(filename, file) < 0) {

--- a/connman/src/6to4.c
+++ b/connman/src/6to4.c
@@ -256,7 +256,7 @@ static bool web_result(GWebResult *result, gpointer user_data)
 
 static void web_debug(const char *str, void *data)
 {
-	connman_info("%s: %s\n", (const char *) data, str);
+	DBG("%s: %s\n", (const char *) data, str);
 }
 
 static gboolean newlink_timeout(gpointer user_data)

--- a/connman/src/config.c
+++ b/connman/src/config.c
@@ -145,7 +145,7 @@ static void unregister_config(gpointer data)
 {
 	struct connman_config *config = data;
 
-	connman_info("Removing configuration %s", config->ident);
+	DBG("Removing configuration %s", config->ident);
 
 	g_hash_table_destroy(config->service_table);
 
@@ -165,7 +165,7 @@ static void unregister_service(gpointer data)
 	if (cleanup)
 		goto free_only;
 
-	connman_info("Removing service configuration %s",
+	DBG("Removing service configuration %s",
 						config_service->ident);
 
 	if (config_service->virtual)
@@ -674,7 +674,7 @@ static bool load_service(GKeyFile *keyfile, const char *group,
 		g_hash_table_insert(config->service_table, service->ident,
 					service);
 
-	connman_info("Adding service configuration %s", service->ident);
+	DBG("Adding service configuration %s", service->ident);
 
 	return true;
 
@@ -769,7 +769,7 @@ static struct connman_config *create_config(const char *ident)
 
 	g_hash_table_insert(config_table, config->ident, config);
 
-	connman_info("Adding configuration %s", config->ident);
+	DBG("Adding configuration %s", config->ident);
 
 	return config;
 }

--- a/connman/src/device.c
+++ b/connman/src/device.c
@@ -1249,7 +1249,7 @@ struct connman_device *connman_device_create_from_index(int index)
 		return NULL;
 
 	if (__connman_device_isfiltered(devname)) {
-		connman_info("Ignoring interface %s (filtered)", devname);
+		DBG("Ignoring interface %s (filtered)", devname);
 		g_free(devname);
 		return NULL;
 	}
@@ -1258,7 +1258,7 @@ struct connman_device *connman_device_create_from_index(int index)
 
 	switch (type) {
 	case CONNMAN_DEVICE_TYPE_UNKNOWN:
-		connman_info("Ignoring interface %s (type unknown)", devname);
+		DBG("Ignoring interface %s (type unknown)", devname);
 		g_free(devname);
 		return NULL;
 	case CONNMAN_DEVICE_TYPE_ETHERNET:

--- a/connman/src/dhcp.c
+++ b/connman/src/dhcp.c
@@ -143,7 +143,7 @@ static void dhcp_valid(struct connman_dhcp *dhcp)
 
 static void dhcp_debug(const char *str, void *data)
 {
-	connman_info("%s: %s", (const char *) data, str);
+	DBG("%s: %s", (const char *) data, str);
 }
 
 static void ipv4ll_stop_client(struct connman_dhcp *dhcp)

--- a/connman/src/dhcpv6.c
+++ b/connman/src/dhcpv6.c
@@ -162,7 +162,7 @@ static bool compare_string_arrays(char **array_a, char **array_b)
 
 static void dhcpv6_debug(const char *str, void *data)
 {
-	connman_info("%s: %s\n", (const char *) data, str);
+	DBG("%s: %s\n", (const char *) data, str);
 }
 
 static gchar *convert_to_hex(unsigned char *buf, int len)

--- a/connman/src/ipconfig.c
+++ b/connman/src/ipconfig.c
@@ -335,7 +335,7 @@ int __connman_ipconfig_set_rp_filter()
 
 	set_rp_filter(2);
 
-	connman_info("rp_filter set to 2 (loose mode routing), "
+	DBG("rp_filter set to 2 (loose mode routing), "
 			"old value was %d", value);
 
 	return value;
@@ -345,7 +345,7 @@ void __connman_ipconfig_unset_rp_filter(int old_value)
 {
 	set_rp_filter(old_value);
 
-	connman_info("rp_filter restored to %d", old_value);
+	DBG("rp_filter restored to %d", old_value);
 }
 
 bool __connman_ipconfig_ipv6_privacy_enabled(struct connman_ipconfig *ipconfig)
@@ -382,7 +382,7 @@ static void free_ipdevice(gpointer data)
 	struct connman_ipdevice *ipdevice = data;
 	char *ifname = connman_inet_ifname(ipdevice->index);
 
-	connman_info("%s {remove} index %d", ifname, ipdevice->index);
+	DBG("%s {remove} index %d", ifname, ipdevice->index);
 
 	if (ipdevice->config_ipv4) {
 		__connman_ipconfig_unref(ipdevice->config_ipv4);
@@ -437,9 +437,9 @@ static void update_stats(struct connman_ipdevice *ipdevice,
 	if (stats->rx_packets == 0 && stats->tx_packets == 0)
 		return;
 
-	connman_info("%s {RX} %llu packets %llu bytes", ifname,
+	DBG("%s {RX} %llu packets %llu bytes", ifname,
 					stats->rx_packets, stats->rx_bytes);
-	connman_info("%s {TX} %llu packets %llu bytes", ifname,
+	DBG("%s {TX} %llu packets %llu bytes", ifname,
 					stats->tx_packets, stats->tx_bytes);
 
 	if (!ipdevice->config_ipv4 && !ipdevice->config_ipv6)
@@ -508,7 +508,7 @@ void __connman_ipconfig_newlink(int index, unsigned short type,
 
 	g_hash_table_insert(ipdevice_hash, GINT_TO_POINTER(index), ipdevice);
 
-	connman_info("%s {create} index %d type %d <%s>", ifname,
+	DBG("%s {create} index %d type %d <%s>", ifname,
 						index, type, type2str(type));
 
 update:
@@ -552,7 +552,7 @@ update:
 	if (flags & IFF_LOWER_UP)
 		g_string_append(str, ",LOWER_UP");
 
-	connman_info("%s {update} flags %u <%s>", ifname, flags, str->str);
+	DBG("%s {update} flags %u <%s>", ifname, flags, str->str);
 
 	g_string_free(str, TRUE);
 
@@ -679,7 +679,7 @@ void __connman_ipconfig_newaddr(int index, int family, const char *label,
 								ipaddress);
 
 	ifname = connman_inet_ifname(index);
-	connman_info("%s {add} address %s/%u label %s family %d",
+	DBG("%s {add} address %s/%u label %s family %d",
 		ifname, address, prefixlen, label, family);
 
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4)
@@ -755,7 +755,7 @@ void __connman_ipconfig_deladdr(int index, int family, const char *label,
 	g_free(ipaddress);
 
 	ifname = connman_inet_ifname(index);
-	connman_info("%s {del} address %s/%u label %s", ifname,
+	DBG("%s {del} address %s/%u label %s", ifname,
 						address, prefixlen, label);
 
 	if ((ipdevice->flags & (IFF_RUNNING | IFF_LOWER_UP)) != (IFF_RUNNING | IFF_LOWER_UP))
@@ -847,7 +847,7 @@ void __connman_ipconfig_newroute(int index, int family, unsigned char scope,
 		}
 	}
 
-	connman_info("%s {add} route %s gw %s scope %u <%s>",
+	DBG("%s {add} route %s gw %s scope %u <%s>",
 		ifname, dst, gateway, scope, scope2str(scope));
 
 out:
@@ -914,7 +914,7 @@ void __connman_ipconfig_delroute(int index, int family, unsigned char scope,
 		}
 	}
 
-	connman_info("%s {del} route %s gw %s scope %u <%s>",
+	DBG("%s {del} route %s gw %s scope %u <%s>",
 		ifname, dst, gateway, scope, scope2str(scope));
 
 out:

--- a/connman/src/main.c
+++ b/connman/src/main.c
@@ -424,7 +424,7 @@ static gboolean signal_handler(GIOChannel *channel, GIOCondition cond,
 	case SIGINT:
 	case SIGTERM:
 		if (__terminated == 0) {
-			connman_info("Terminating");
+			DBG("Terminating");
 			g_main_loop_quit(main_loop);
 		}
 

--- a/connman/src/ntp.c
+++ b/connman/src/ntp.c
@@ -258,7 +258,7 @@ static void decode_msg(void *base, size_t len, struct timeval *tv,
 		/* RFC 4330 ch 8 Kiss-of-Death packet */
 		uint32_t code = ntohl(msg->refid);
 
-		connman_info("Skipping server %s KoD code %c%c%c%c",
+		DBG("Skipping server %s KoD code %c%c%c%c",
 			timeserver, code >> 24, code >> 16 & 0xff,
 			code >> 8 & 0xff, code & 0xff);
 		next_server();
@@ -320,7 +320,7 @@ static void decode_msg(void *base, size_t len, struct timeval *tv,
 
 	poll_id = g_timeout_add_seconds(transmit_delay, next_poll, NULL);
 
-	connman_info("ntp: time slew %+.6f s", offset);
+	DBG("ntp: time slew %+.6f s", offset);
 
 	if (offset < STEPTIME_MIN_OFFSET && offset > -STEPTIME_MIN_OFFSET) {
 		struct timeval adj;

--- a/connman/src/plugin.c
+++ b/connman/src/plugin.c
@@ -85,7 +85,7 @@ static bool check_plugin(struct connman_plugin_desc *desc,
 			if (g_pattern_match_simple(*excludes, desc->name))
 				break;
 		if (*excludes) {
-			connman_info("Excluding %s", desc->description);
+			DBG("Excluding %s", desc->description);
 			return false;
 		}
 	}
@@ -95,7 +95,7 @@ static bool check_plugin(struct connman_plugin_desc *desc,
 			if (g_pattern_match_simple(*patterns, desc->name))
 				break;
 		if (!*patterns) {
-			connman_info("Ignoring %s", desc->description);
+			DBG("Ignoring %s", desc->description);
 			return false;
 		}
 	}

--- a/connman/src/rtnl.c
+++ b/connman/src/rtnl.c
@@ -41,6 +41,7 @@
 #include <glib.h>
 
 #include "connman.h"
+#include "log.h"
 
 #ifndef ARPHDR_PHONET_PIPE
 #define ARPHDR_PHONET_PIPE (821)
@@ -50,8 +51,8 @@
 #define ARPHRD_RAWIP (530)
 #endif
 
-#define print(arg...) do { if (0) connman_info(arg); } while (0)
-//#define print(arg...) connman_info(arg)
+#define print(arg...) do { if (0) DBG(arg); } while (0)
+//#define print(arg...) DBG(arg)
 
 struct watch_data {
 	unsigned int id;
@@ -448,11 +449,11 @@ static void process_newlink(unsigned short type, int index, unsigned flags,
 	}
 
 	if (memcmp(&address, &compare, ETH_ALEN) != 0)
-		connman_info("%s {newlink} index %d address %s mtu %u",
+        DBG("%s {newlink} index %d address %s mtu %u",
 						ifname, index, str, mtu);
 
 	if (operstate != 0xff)
-		connman_info("%s {newlink} index %d operstate %u <%s>",
+		DBG("%s {newlink} index %d operstate %u <%s>",
 						ifname, index, operstate,
 						operstate2str(operstate));
 
@@ -511,7 +512,7 @@ static void process_dellink(unsigned short type, int index, unsigned flags,
 		return;
 
 	if (operstate != 0xff)
-		connman_info("%s {dellink} index %d operstate %u <%s>",
+		DBG("%s {dellink} index %d operstate %u <%s>",
 						ifname, index, operstate,
 						operstate2str(operstate));
 

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -4504,7 +4504,7 @@ static DBusMessage *move_service(DBusConnection *conn,
 		 * routes defined for a given VPN.
 		 */
 		if (!__connman_provider_check_routes(target->provider)) {
-			connman_info("Cannot move service. "
+			DBG("Cannot move service. "
 				"No routes defined for provider %s",
 				__connman_provider_get_ident(target->provider));
 			return __connman_error_invalid_service(msg);

--- a/connman/src/task.c
+++ b/connman/src/task.c
@@ -378,7 +378,7 @@ static gboolean check_kill(gpointer user_data)
 	pid_t pid = GPOINTER_TO_INT(user_data);
 	if (pid > 0) {
 		if (kill(pid, 0) == 0) {
-			connman_info("pid %d was not killed, "
+			DBG("pid %d was not killed, "
 					"retrying after 2 sec", pid);
 			g_timeout_add_seconds(2, kill_timeout,
 					GINT_TO_POINTER(pid));

--- a/connman/src/technology.c
+++ b/connman/src/technology.c
@@ -1323,7 +1323,7 @@ void __connman_technology_add_interface(enum connman_service_type type,
 	}
 
 	name = connman_inet_ifname(index);
-	connman_info("Adding interface %s [ %s ]", name,
+	DBG("Adding interface %s [ %s ]", name,
 				__connman_service_type2string(type));
 
 	technology = technology_find(type);
@@ -1374,7 +1374,7 @@ void __connman_technology_remove_interface(enum connman_service_type type,
 	}
 
 	name = connman_inet_ifname(index);
-	connman_info("Remove interface %s [ %s ]", name,
+	DBG("Remove interface %s [ %s ]", name,
 				__connman_service_type2string(type));
 	g_free(name);
 

--- a/connman/src/tethering.c
+++ b/connman/src/tethering.c
@@ -99,7 +99,7 @@ const char *__connman_tethering_get_bridge(void)
 
 static void dhcp_server_debug(const char *str, void *data)
 {
-	connman_info("%s: %s\n", (const char *) data, str);
+	DBG("%s: %s\n", (const char *) data, str);
 }
 
 static void dhcp_server_error(GDHCPServerError error)

--- a/connman/src/timeserver.c
+++ b/connman/src/timeserver.c
@@ -43,7 +43,7 @@ static int resolv_id = 0;
 
 static void resolv_debug(const char *str, void *data)
 {
-	connman_info("%s: %s\n", (const char *) data, str);
+	DBG("%s: %s\n", (const char *) data, str);
 }
 static void save_timeservers(char **servers)
 {

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -412,7 +412,7 @@ static void xml_wispr_parser_callback(const char *str, gpointer user_data)
 
 static void web_debug(const char *str, void *data)
 {
-	connman_info("%s: %s\n", (const char *) data, str);
+	DBG("%s: %s\n", (const char *) data, str);
 }
 
 static void wispr_portal_error(struct connman_wispr_portal_context *wp_context)
@@ -434,19 +434,19 @@ static void portal_manage_status(GWebResult *result,
 	/* We currently don't do anything with this info */
 	if (g_web_result_get_header(result, "X-ConnMan-Client-IP",
 				&str))
-		connman_info("Client-IP: %s", str);
+		DBG("Client-IP: %s", str);
 
 	if (g_web_result_get_header(result, "X-ConnMan-Client-Country",
 				&str))
-		connman_info("Client-Country: %s", str);
+		DBG("Client-Country: %s", str);
 
 	if (g_web_result_get_header(result, "X-ConnMan-Client-Region",
 				&str))
-		connman_info("Client-Region: %s", str);
+		DBG("Client-Region: %s", str);
 
 	if (g_web_result_get_header(result, "X-ConnMan-Client-Timezone",
 				&str))
-		connman_info("Client-Timezone: %s", str);
+		DBG("Client-Timezone: %s", str);
 
 	free_connman_wispr_portal_context(wp_context);
 

--- a/connman/src/wpad.c
+++ b/connman/src/wpad.c
@@ -42,7 +42,7 @@ static GHashTable *wpad_list = NULL;
 
 static void resolv_debug(const char *str, void *data)
 {
-	connman_info("%s: %s\n", (const char *) data, str);
+	DBG("%s: %s\n", (const char *) data, str);
 }
 
 static void free_wpad(gpointer data)

--- a/connman/vpn/main.c
+++ b/connman/vpn/main.c
@@ -129,7 +129,7 @@ static gboolean signal_handler(GIOChannel *channel, GIOCondition cond,
 	case SIGINT:
 	case SIGTERM:
 		if (__terminated == 0) {
-			connman_info("Terminating");
+			DBG("Terminating");
 			g_main_loop_quit(main_loop);
 		}
 

--- a/connman/vpn/vpn-config.c
+++ b/connman/vpn/vpn-config.c
@@ -80,7 +80,7 @@ static void unregister_config(gpointer data)
 {
 	struct vpn_config *config = data;
 
-	connman_info("Removing configuration %s", config->ident);
+	DBG("Removing configuration %s", config->ident);
 
 	g_hash_table_destroy(config->provider_table);
 
@@ -101,7 +101,7 @@ static void unregister_provider(gpointer data)
 
 	provider_id = config_provider->provider_identifier;
 
-	connman_info("Removing provider configuration %s provider %s",
+	DBG("Removing provider configuration %s provider %s",
 				config_provider->ident, provider_id);
 
 	provider = __vpn_provider_lookup(provider_id);
@@ -274,7 +274,7 @@ static int load_provider(GKeyFile *keyfile, const char *group,
 		goto err;
 	}
 
-	connman_info("Added provider configuration %s",
+	DBG("Added provider configuration %s",
 						config_provider->ident);
 	return 0;
 
@@ -387,7 +387,7 @@ static struct vpn_config *create_config(const char *ident)
 
 	g_hash_table_insert(config_table, config->ident, config);
 
-	connman_info("Adding configuration %s", config->ident);
+	DBG("Adding configuration %s", config->ident);
 
 	return config;
 }

--- a/connman/vpn/vpn-ipconfig.c
+++ b/connman/vpn/vpn-ipconfig.c
@@ -386,7 +386,7 @@ void __vpn_ipconfig_newlink(int index, unsigned short type,
 
 	g_hash_table_insert(ipdevice_hash, GINT_TO_POINTER(index), ipdevice);
 
-	connman_info("%s {create} index %d type %d <%s>", ipdevice->ifname,
+	DBG("%s {create} index %d type %d <%s>", ipdevice->ifname,
 						index, type, type2str(type));
 
 update:
@@ -412,7 +412,7 @@ update:
 	if (flags & IFF_LOWER_UP)
 		g_string_append(str, ",LOWER_UP");
 
-	connman_info("%s {update} flags %u <%s>", ipdevice->ifname,
+	DBG("%s {update} flags %u <%s>", ipdevice->ifname,
 							flags, str->str);
 
 	g_string_free(str, TRUE);
@@ -435,7 +435,7 @@ static void free_ipdevice(gpointer data)
 {
 	struct vpn_ipdevice *ipdevice = data;
 
-	connman_info("%s {remove} index %d", ipdevice->ifname,
+	DBG("%s {remove} index %d", ipdevice->ifname,
 							ipdevice->index);
 
 	g_free(ipdevice->ipv4_gateway);

--- a/connman/vpn/vpn-rtnl.c
+++ b/connman/vpn/vpn-rtnl.c
@@ -50,7 +50,7 @@
 #define ARPHDR_PHONET_PIPE (821)
 #endif
 
-#define print(arg...) do { if (0) connman_info(arg); } while (0)
+#define print(arg...) do { if (0) DBG(arg); } while (0)
 #define debug(arg...) do { if (0) DBG(arg); } while (0)
 
 struct watch_data {
@@ -304,11 +304,11 @@ static void process_newlink(unsigned short type, int index, unsigned flags,
 	}
 
 	if (memcmp(&address, &compare, ETH_ALEN) != 0)
-		connman_info("%s {newlink} index %d address %s mtu %u",
+		DBG("%s {newlink} index %d address %s mtu %u",
 						ifname, index, str, mtu);
 
 	if (operstate != 0xff)
-		connman_info("%s {newlink} index %d operstate %u <%s>",
+		DBG("%s {newlink} index %d operstate %u <%s>",
 						ifname, index, operstate,
 						operstate2str(operstate));
 
@@ -352,7 +352,7 @@ static void process_dellink(unsigned short type, int index, unsigned flags,
 	extract_link(msg, bytes, NULL, &ifname, NULL, &operstate, &stats);
 
 	if (operstate != 0xff)
-		connman_info("%s {dellink} index %d operstate %u <%s>",
+		DBG("%s {dellink} index %d operstate %u <%s>",
 						ifname, index, operstate,
 						operstate2str(operstate));
 


### PR DESCRIPTION
connman_info does not have file names in it's output, so it would not
be included in the block out by doing -d '*:!src/rtnl.c'

This effectively makes the output more manageable and readable when
debugging.
This included stat and newlink info clogging the output.
