### PR TITLE
dhcp: Remove leftover source if service has been freed

### DIFF
--- a/connman/src/dhcp.c
+++ b/connman/src/dhcp.c
@@ -222,6 +222,9 @@ static gboolean dhcp_retry_cb(gpointer user_data)
 	dhcp->timeout = 0;
 
 	service = connman_service_lookup_from_network(dhcp->network);
+	if (!service)
+		return FALSE;
+
 	ipconfig = __connman_service_get_ip4config(service);
 
 	g_dhcp_client_start(dhcp->dhcp_client,


### PR DESCRIPTION
dhcp_retry_cb() will try to use an inexistent service causing a crash
when the system is connected to a network with no dhcp service
providers check if service exists and remove source if it doesn't
