### PR TITLE
[connman] dnsproxy: Prefer responses with ancount>0 if append_domain is true

### DIFF
--- a/connman/src/dnsproxy.c
+++ b/connman/src/dnsproxy.c
@@ -1805,8 +1805,13 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
 		cache_update(data, reply, reply_len);
 	}
 
-	if (hdr->rcode > 0 && req->numresp < req->numserv)
-		return -EINVAL;
+	if (req->numresp < req->numserv) {
+		if (hdr->rcode > ns_r_noerror) {
+			return -EINVAL;
+		} else if (hdr->ancount == 0 && req->append_domain) {
+			return -EINVAL;
+		}
+	}
 
 	request_list = g_slist_remove(request_list, req);
 


### PR DESCRIPTION
If domain_append is true and a valid domain tld (eg. com. net. bz.) is queried we need to make sure that responses with ancount>0 are preferred over ones with ancount==0. This is due queries againts valid domain tld's will always have response code ns_r_noerror even there are no valid records. This will solve the issue dnsproxy not returning the expected response if hostname queried is equal to any valid tld.
