### PR TITLE
[connman] service: check for 32-bit counter wraparound

### DIFF
--- a/connman/configure.ac
+++ b/connman/configure.ac
@@ -396,6 +396,13 @@ AM_CONDITIONAL(VPN, test "${enable_openconnect}" != "no" -o \
 			"${enable_l2tp}" != "no" -o \
 			"${enable_pptp}" != "no")
 
+AC_ARG_ENABLE(counter-wraparound, AC_HELP_STRING([--enable-counter-wraparound],
+			[enable checking 32-bit statistics counter wraparound]), [
+	if (test "${enableval}" = "yes" ); then
+		CFLAGS="$CFLAGS -DCOUNTER_WRAPAROUND_AT_32BIT"
+	fi
+])
+
 AC_OUTPUT(Makefile include/version.h src/connman.service
 		vpn/connman-vpn.service	vpn/net.connman.vpn.service
 		scripts/connman	connman.pc src/net.connman.service)

--- a/rpm/connman.spec
+++ b/rpm/connman.spec
@@ -105,7 +105,8 @@ Documentation for connman.
     --enable-client \
     --enable-test \
     --with-systemdunitdir=/%{_lib}/systemd/system \
-    --enable-systemd
+    --enable-systemd \
+    --enable-counter-wraparound
 
 make %{?jobs:-j%jobs}
 


### PR DESCRIPTION
Depending on device driver implementation, network statistics counters
may wrap around at 4 GiB on a 32-bit kernel. To work around this,
check for wraparound when updating statistics. Since there is no other
way to reset network statistics than to unload drivers there should not
be much chance for false positives in wraparound detection.

Of course, only a single wraparound can be detected so counters need
to be updated frequently enough.
