### PR TITLE
[connman] Append extra wifi service properties

### DIFF
--- a/connman/doc/service-api.txt
+++ b/connman/doc/service-api.txt
@@ -191,6 +191,32 @@ Properties	string State [readonly]
 			This property might be only present for WiFi
 			services.
 
+		string BSSID [readonly]
+
+			If the service type is WiFi, then this property
+			indicates the BSSID of the service.
+
+		uint32 MaxRate [readonly]
+
+			If the service type is WiFi, then this property
+			indicates the Maximum speed(bps) of the service.
+
+		uint16 Frequency [readonly]
+
+			If the service type is WiFi, then this property
+			indicates the frequency band(MHz) of the service.
+
+		string EncryptionMode [readonly]
+
+			If the service type is WiFi, then this property
+			indicates the key encryption mode.
+
+			Possible values are "none", "wep", "tkip", "aes"
+			and "mixed".
+
+			This property might be only present for WiFi
+			services.
+
 		uint8 Strength [readonly]
 
 			Indicates the signal strength of the service. This

--- a/connman/gsupplicant/gsupplicant.h
+++ b/connman/gsupplicant/gsupplicant.h
@@ -259,6 +259,13 @@ const char *g_supplicant_peer_get_identifier(GSupplicantPeer *peer);
 const void *g_supplicant_peer_get_device_address(GSupplicantPeer *peer);
 const char *g_supplicant_peer_get_name(GSupplicantPeer *peer);
 
+/*
+ * Description: Network client requires additional wifi specific info
+ */
+const unsigned char *g_supplicant_network_get_bssid(GSupplicantNetwork *network);
+unsigned int g_supplicant_network_get_maxrate(GSupplicantNetwork *network);
+const char *g_supplicant_network_get_enc_mode(GSupplicantNetwork *network);
+
 struct _GSupplicantCallbacks {
 	void (*system_ready) (void);
 	void (*system_killed) (void);

--- a/connman/gsupplicant/supplicant.c
+++ b/connman/gsupplicant/supplicant.c
@@ -1011,6 +1011,53 @@ const char *g_supplicant_peer_get_name(GSupplicantPeer *peer)
 	return peer->name;
 }
 
+/*
+ * Description: Network client requires additional wifi specific info
+ */
+const unsigned char *g_supplicant_network_get_bssid(GSupplicantNetwork *network)
+{
+	if (!network || !network->best_bss)
+		return NULL;
+
+	return (const unsigned char *)network->best_bss->bssid;
+}
+
+unsigned int g_supplicant_network_get_maxrate(GSupplicantNetwork *network)
+{
+	if (!network || !network->best_bss)
+		return 0;
+
+	return network->best_bss->maxrate;
+}
+
+const char *g_supplicant_network_get_enc_mode(GSupplicantNetwork *network)
+{
+	if (!network || !network->best_bss)
+		return NULL;
+
+	if (network->best_bss->security == G_SUPPLICANT_SECURITY_PSK ||
+	    network->best_bss->security == G_SUPPLICANT_SECURITY_IEEE8021X) {
+		unsigned int pairwise;
+
+		pairwise = network->best_bss->rsn_pairwise |
+				network->best_bss->wpa_pairwise;
+
+		if ((pairwise & G_SUPPLICANT_PAIRWISE_CCMP) &&
+		    (pairwise & G_SUPPLICANT_PAIRWISE_TKIP))
+			return "mixed";
+		else if (pairwise & G_SUPPLICANT_PAIRWISE_CCMP)
+			return "aes";
+		else if (pairwise & G_SUPPLICANT_PAIRWISE_TKIP)
+			return "tkip";
+
+	} else if (network->best_bss->security == G_SUPPLICANT_SECURITY_WEP)
+		return "wep";
+	else if (network->best_bss->security == G_SUPPLICANT_SECURITY_NONE)
+		return "none";
+
+	return NULL;
+}
+
 static void merge_network(GSupplicantNetwork *network)
 {
 	GString *str;

--- a/connman/include/network.h
+++ b/connman/include/network.h
@@ -117,6 +117,22 @@ int connman_network_set_nameservers(struct connman_network *network,
 				const char *nameservers);
 int connman_network_set_domain(struct connman_network *network,
 			             const char *domain);
+
+/*
+ * Description: Network client requires additional wifi specific info
+ */
+int connman_network_set_bssid(struct connman_network *network,
+				const unsigned char *bssid);
+unsigned char *connman_network_get_bssid(struct connman_network *network);
+
+int connman_network_set_maxrate(struct connman_network *network,
+				unsigned int maxrate);
+unsigned int connman_network_get_maxrate(struct connman_network *network);
+
+int connman_network_set_enc_mode(struct connman_network *network,
+				const char *encryption_mode);
+const char *connman_network_get_enc_mode(struct connman_network *network);
+
 int connman_network_set_name(struct connman_network *network,
 							const char *name);
 int connman_network_set_strength(struct connman_network *network,

--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -2003,7 +2003,14 @@ static void network_added(GSupplicantNetwork *supplicant_network)
 
 	connman_network_set_frequency(network,
 			g_supplicant_network_get_frequency(supplicant_network));
-
+    
+    	connman_network_set_bssid(network,
+    			g_supplicant_network_get_bssid(supplicant_network));
+    	connman_network_set_maxrate(network,
+    			g_supplicant_network_get_maxrate(supplicant_network));
+    	connman_network_set_enc_mode(network,
+    			g_supplicant_network_get_enc_mode(supplicant_network));
+    
 	connman_network_set_available(network, true);
 	connman_network_set_string(network, "WiFi.Mode", mode);
 
@@ -2058,7 +2065,11 @@ static void network_changed(GSupplicantNetwork *network, const char *property)
 	struct wifi_data *wifi;
 	const char *name, *identifier;
 	struct connman_network *connman_network;
-
+    
+    const unsigned char *bssid;
+    unsigned int maxrate;
+    uint16_t frequency;
+    
 	interface = g_supplicant_network_get_interface(network);
 	wifi = g_supplicant_interface_get_data(interface);
 	identifier = g_supplicant_network_get_identifier(network);
@@ -2078,6 +2089,14 @@ static void network_changed(GSupplicantNetwork *network, const char *property)
 					calculate_strength(network));
 	       connman_network_update(connman_network);
 	}
+
+	bssid = g_supplicant_network_get_bssid(network);
+	maxrate = g_supplicant_network_get_maxrate(network);
+	frequency = g_supplicant_network_get_frequency(network);
+
+	connman_network_set_bssid(connman_network, bssid);
+	connman_network_set_maxrate(connman_network, maxrate);
+	connman_network_set_frequency(connman_network, frequency);
 }
 
 static void peer_found(GSupplicantPeer *peer)

--- a/connman/src/network.c
+++ b/connman/src/network.c
@@ -41,6 +41,9 @@
  */
 #define RS_REFRESH_TIMEOUT	3
 
+#define WIFI_ENCYPTION_MODE_LEN_MAX 6
+#define WIFI_BSSID_LEN_MAX 6
+
 static GSList *network_list = NULL;
 static GSList *driver_list = NULL;
 
@@ -87,6 +90,9 @@ struct connman_network {
 		bool wps;
 		bool use_wps;
 		char *pin_wps;
+		char encryption_mode[WIFI_ENCYPTION_MODE_LEN_MAX];
+		unsigned char bssid[WIFI_BSSID_LEN_MAX];
+		unsigned int maxrate;
 	} wifi;
 
 };
@@ -1722,6 +1728,67 @@ int connman_network_set_ipaddress(struct connman_network *network,
 
 	return 0;
 }
+
+/*
+ * Description: Network client requires additional wifi specific info
+ */
+int connman_network_set_bssid(struct connman_network *network,
+				const unsigned char *bssid)
+{
+	int i = 0;
+
+	if (!bssid)
+		return -EINVAL;
+
+	DBG("network %p bssid %02x:%02x:%02x:%02x:%02x:%02x", network,
+			bssid[0], bssid[1], bssid[2],
+			bssid[3], bssid[4], bssid[5]);
+
+	for (;i < WIFI_BSSID_LEN_MAX;i++)
+		network->wifi.bssid[i] = bssid[i];
+
+	return 0;
+}
+
+unsigned char *connman_network_get_bssid(struct connman_network *network)
+{
+	return (unsigned char *)network->wifi.bssid;
+}
+
+int connman_network_set_maxrate(struct connman_network *network,
+				unsigned int maxrate)
+{
+	DBG("network %p maxrate %d", network, maxrate);
+
+	network->wifi.maxrate = maxrate;
+
+	return 0;
+}
+
+unsigned int connman_network_get_maxrate(struct connman_network *network)
+{
+	return network->wifi.maxrate;
+}
+
+int connman_network_set_enc_mode(struct connman_network *network,
+				const char *encryption_mode)
+{
+	if (!encryption_mode)
+		return -EINVAL;
+
+	DBG("network %p encryption mode %s", network, encryption_mode);
+
+	g_strlcpy(network->wifi.encryption_mode, encryption_mode,
+					WIFI_ENCYPTION_MODE_LEN_MAX);
+
+	return 0;
+}
+
+const char *connman_network_get_enc_mode(struct connman_network *network)
+{
+	return (const char *)network->wifi.encryption_mode;
+}
+
 
 int connman_network_set_nameservers(struct connman_network *network,
 				const char *nameservers)


### PR DESCRIPTION
This commit contains two patches:

From a5eded6f3a9cff14ab19ee696ce27cedd633cca3 Mon Sep 17 00:00:00 2001
From: Arron Wang arron.wang@intel.com
Date: Mon, 24 Sep 2012 14:42:02 +0800
Subject: [PATCH 04/63] Tizen: Append extra wifi service property

Append wifi property bssid, maxrate, frequency, encryptionmode to wifi
service

From 0b571435f46d1c2acbe154c43d2e2b28403694c2 Mon Sep 17 00:00:00 2001
From: Arron Wang arron.wang@intel.com
Date: Mon, 24 Sep 2012 14:18:07 +0800
Subject: [PATCH 03/63] Tizen: Export more wifi info in ConnMan network
API

Network client requires additional wifi specific info

Export the BSSID property
Export the MaxRate property
Export the detailed info for encryption mode(mixed,aes,tkip,wep,none)

Export the connman_network get/set method for bssid, maxrate,
encryption_mode property
