### PR TITLE
[connman] gdhcp: adjust discovery/request timeout and retry values

### DIFF
--- a/connman/gdhcp/client.c
+++ b/connman/gdhcp/client.c
@@ -47,11 +47,11 @@
 #include "common.h"
 #include "ipv4ll.h"
 
-#define DISCOVER_TIMEOUT 3
-#define DISCOVER_RETRIES 10
+#define DISCOVER_TIMEOUT 5
+#define DISCOVER_RETRIES 6
 
-#define REQUEST_TIMEOUT 3
-#define REQUEST_RETRIES 5
+#define REQUEST_TIMEOUT 5
+#define REQUEST_RETRIES 3
 
 typedef enum _listen_mode {
 	L_NONE,


### PR DESCRIPTION
Some dhcp servers are acting lazy (eg. Buffalo WBMR-G125)
therefore 3 second timeout value for discovery or request
is not enough. Adjusting the timeout value from 3 seconds
to 5 will fix the problem together with adjusting the
retry value not to increase the total time for waiting
for getting the lease.
