### PR TITLE
[connman] Fix copy and paste error with previous commit.

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -2402,7 +2402,7 @@ static void __connman_service_counter_append(const char *counter, struct connman
     } else {
         bzero(&data, sizeof(data));
 
-        if (__connman_stats_get(service, FALSE, &data) == 0)
+        if (__connman_stats_get(service, TRUE, &data) == 0)
             dataPointer = &data;
         else
             dataPointer = 0;


### PR DESCRIPTION
Commit 25ece468eb558b7dd13dedaa07694a14539c81bc had a typo which caused
home data stats to be return for roaming stats in some situations.
