### PR TITLE
[connman] Don't treat counters for cellular services differently.

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -2304,10 +2304,6 @@ int __connman_service_counter_register(const char *counter)
 
 static void __connman_service_counter_append_saved(const char *counter, const char *identifier)
 {
-    // Ignore saved cellular services. Only report usage for the currently active SIM
-    if (strncmp(identifier, "cellular_", 9) == 0)
-        return;
-
     struct connman_service *service = connman_service_create();
     if (service == NULL)
         return;


### PR DESCRIPTION
Previously only the usage statistics for available cellular services
were being sent. The reasoning being that the user is only interested
in the usage for the currently inserted SIM card. This is still a valid
use case, however, doing at this level can lead to issues in the UI.

The available cellular service can temporarily disappear during normal
operation of the device. This can happen, for example, due to a change
in cellular technology. If an application requests data counters at
this time and mobile data will not be connected (because it is disabled
or due to a usable WLAN connection) then cellular usage counters will
not be sent to the application.

Always send initial cellular usage data for all known cellular services
and expect applications to only show the desired data.
