### PR TITLE
plugins: Dummy bluetooth plugin for rfkill setup

### DIFF
--- a/connman/Makefile.plugins
+++ b/connman/Makefile.plugins
@@ -58,6 +58,18 @@ builtin_modules += jolla_wakeup_timer
 builtin_sources += plugins/jolla_wakeup_timer.c
 endif
 
+if DATAFILES
+if SYSTEMD
+if JOLLA_RFKILL
+builtin_modules += jolla_rfkill
+builtin_sources += plugins/jolla-rfkill.c
+systemdunit_DATA += plugins/jolla-rfkill-hciwait.service
+plugins_jolla_rfkill_hciwait_SOURCES = plugins/jolla-rfkill-hciwait.c
+sbin_PROGRAMS += plugins/jolla-rfkill-hciwait
+endif
+endif
+endif
+
 if OFONO
 builtin_modules += ofono
 builtin_sources += plugins/mcc.h plugins/ofono.c

--- a/connman/configure.ac
+++ b/connman/configure.ac
@@ -88,6 +88,27 @@ AC_ARG_ENABLE(systemd,
 			CFLAGS="$CFLAGS -DSYSTEMD -lsystemd-daemon"
 fi])
 
+CONNMAN_SERVICE_REQUIRES=dbus.socket
+CONNMAN_SERVICE_AFTER=dbus.socket
+
+if (test "${enable_systemd}" != "no"); then
+   AC_ARG_ENABLE(jolla-rfkill,
+	AC_HELP_STRING([--enable-jolla-rfkill],
+			 [enable jolla rfkill support]),
+			 [enable_jolla_rfkill=${enableval}],
+			 [enable_jolla_rfkill="no"])
+
+   AM_CONDITIONAL(JOLLA_RFKILL, test "${enable_jolla_rfkill}" != "no")
+
+   if (test "${enable_jolla_rfkill}" != "no"); then
+      CONNMAN_SERVICE_REQUIRES=jolla-rfkill-hciwait.service
+      CONNMAN_SERVICE_AFTER=jolla-rfkill-hciwait.service
+   fi
+fi
+
+AC_SUBST(CONNMAN_SERVICE_REQUIRES)
+AC_SUBST(CONNMAN_SERVICE_AFTER)
+
 AC_ARG_WITH(openconnect, AC_HELP_STRING([--with-openconnect=PROGRAM],
         [specify location of openconnect binary]), [path_openconnect=${withval}])
 

--- a/connman/plugins/jolla-rfkill-hciwait.c
+++ b/connman/plugins/jolla-rfkill-hciwait.c
@@ -1,0 +1,261 @@
+/*
+ *
+ *  Connection Manager
+ *
+ *  Copyright (C) 2014 Jolla Ltd.
+ *  Contact: Hannu Mallat <hannu.mallat@jollamobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/* Notify systemd when a BT HCI interface (any of them) is available */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <syslog.h>
+#include <stdarg.h>
+#include <errno.h>
+
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <sys/ioctl.h>
+
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/hci_lib.h>
+
+int debug = 0;
+
+enum hci_status {
+	HCI_ERROR = -1,
+	HCI_CONTINUE = 0,
+	HCI_DONE = 1,
+};
+
+static void ERROR(const char *format, ...)
+{
+	va_list v;
+	va_start(v, format);
+	vsyslog(LOG_ERR, format, v);
+	va_end(v);
+}
+
+static void DEBUG(const char *format, ...)
+{
+	if (debug) {
+		va_list v;
+		va_start(v, format);
+		vsyslog(LOG_DEBUG, format, v);
+		va_end(v);
+	}
+}
+
+/* Return the index of the first found adapter, or -1 if there are none.
+ *
+ * For our purposes it doesn't matter which or how many adapters there
+ * are present, as long as there's one.
+ */
+static int hci_adapter_index(void)
+{
+	struct hci_dev_list_req *dev_list_req = NULL;
+	int hci_socket = -1;
+	int index = -1;
+
+	hci_socket = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
+	if (hci_socket < 0) {
+		ERROR("Can't open socket: %s (%d).", strerror(errno), errno);
+		goto out;
+	}
+
+	dev_list_req = calloc(sizeof(struct hci_dev_req) + sizeof(uint16_t), 1);
+	if (!dev_list_req) {
+		ERROR("Can't allocate buffer: %s (%d).",
+			strerror(errno), errno);
+		goto out;
+	}
+
+	dev_list_req->dev_num = 1;
+	if (ioctl(hci_socket, HCIGETDEVLIST, dev_list_req) < 0) {
+		ERROR("Can't get device list: %s (%d).", strerror(errno), errno);
+		goto out;
+	}
+
+	DEBUG("%s a device.", dev_list_req->dev_num > 0
+		? "Found"
+		: "Did not find");
+
+	if (dev_list_req->dev_num)
+		index = dev_list_req->dev_req->dev_id;
+
+out:
+	if (hci_socket >= 0)
+		close(hci_socket);
+
+	if (dev_list_req)
+		free(dev_list_req);
+
+	return index;
+}
+
+/* Set up a file descriptor for listening for adapter appearance */
+static int hci_listener_setup(void)
+{
+	struct sockaddr_hci hci_addr;
+	struct hci_filter hci_filter;
+	int hci_socket = -1;
+
+	DEBUG("Setting up HCI event listener.");
+
+	hci_socket = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
+	if (hci_socket < 0) {
+		ERROR("Can't open socket: %s (%d)", strerror(errno), errno);
+		goto fail;
+	}
+
+	hci_filter_clear(&hci_filter);
+	hci_filter_set_ptype(HCI_EVENT_PKT, &hci_filter);
+	hci_filter_set_event(EVT_STACK_INTERNAL, &hci_filter);
+	if (setsockopt(hci_socket, SOL_HCI, HCI_FILTER, &hci_filter,
+			sizeof(hci_filter)) < 0) {
+		ERROR("Can't set filter: %s (%d)", strerror(errno), errno);
+		goto fail;
+	}
+
+	memset(&hci_addr, 0, sizeof(hci_addr));
+	hci_addr.hci_family = AF_BLUETOOTH;
+	hci_addr.hci_dev = HCI_DEV_NONE;
+	if (bind(hci_socket, (struct sockaddr *)&hci_addr,
+			sizeof(hci_addr)) < 0) {
+		ERROR("Can't bind HCI socket: %s (%d)", strerror(errno), errno);
+		goto fail;
+	}
+
+	DEBUG("HCI event listener set up.");
+
+	return hci_socket;
+
+fail:
+	if (hci_socket >= 0)
+		close(hci_socket);
+
+	return -1;
+}
+
+static enum hci_status hci_event(int hci_socket)
+{
+	unsigned char buf[HCI_MAX_FRAME_SIZE], *ptr = buf;
+	evt_stack_internal *stack_internal = NULL;
+	evt_si_device *device = NULL;
+	ssize_t len;
+
+	DEBUG("Reading a HCI event");
+
+	len = read(hci_socket, buf, sizeof(buf));
+	if (len < 0) {
+		if (errno == EAGAIN)
+			return HCI_CONTINUE;
+
+		ERROR("Cannot read HCI socket: %s (%d)", strerror(errno), errno);
+		return HCI_ERROR;
+	}
+
+	if (*ptr != HCI_EVENT_PKT)
+		return HCI_CONTINUE;
+	ptr++;
+
+	if (((hci_event_hdr *) ptr)->evt != EVT_STACK_INTERNAL)
+		return HCI_CONTINUE;
+	ptr += HCI_EVENT_HDR_SIZE;
+
+	stack_internal = (evt_stack_internal *) ptr;
+	if (stack_internal->type == EVT_SI_DEVICE) {
+		device = (evt_si_device *)&stack_internal->data;
+		if (device->event == HCI_DEV_REG) {
+			DEBUG("HCI device %d registered", device->dev_id);
+			return HCI_DONE;
+		}
+	}
+
+	return HCI_CONTINUE;
+}
+
+int main(int argc, char *argv[])
+{
+	int hci_socket = -1;
+	int e = EXIT_FAILURE;
+	int log_flags = LOG_PID;
+	int opt;
+
+	while ((opt = getopt(argc, argv, "ds")) != -1) {
+		switch (opt) {
+		case 'd':
+			debug = 1;
+			break;
+		case 's':
+			log_flags |= LOG_PERROR;
+			break;
+		}
+	}
+
+	openlog("jolla-rfkill-hciwait", log_flags, LOG_USER);
+
+	hci_socket = hci_listener_setup();
+	if (hci_socket < 0)
+		goto out;
+
+	if (hci_adapter_index() >= 0)
+		goto ready;
+
+	DEBUG("Waiting for events");
+
+	while (1) {
+		fd_set read_set;
+
+		FD_ZERO(&read_set);
+		FD_SET(hci_socket, &read_set);
+
+		if (select(hci_socket + 1, &read_set, NULL, NULL, NULL) < 0) {
+			ERROR("Cannot listen for events: %s (%d)",
+				strerror(errno), errno);
+			goto out;
+		}
+
+		switch (hci_event(hci_socket)) {
+		case HCI_DONE:
+			DEBUG("HCI interface registration seen, done.");
+			goto ready;
+		case HCI_CONTINUE:
+			DEBUG("Continuing.");
+			break;
+		case HCI_ERROR:
+			goto out;
+		}
+	}
+
+ready:
+	e = EXIT_SUCCESS;
+
+out:
+	if (hci_socket >= 0)
+		close(hci_socket);
+
+	closelog();
+
+	exit(e);
+}

--- a/connman/plugins/jolla-rfkill-hciwait.service
+++ b/connman/plugins/jolla-rfkill-hciwait.service
@@ -1,0 +1,15 @@
+#
+# Wait unti a BT HCI adapter is available.
+#
+
+[Unit]
+Description=Wait for Bluetooth HCI adapter
+Before=connman.service
+After=dbus.socket
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/jolla-rfkill-hciwait
+
+[Install]
+WantedBy=multi-user.target

--- a/connman/plugins/jolla-rfkill.c
+++ b/connman/plugins/jolla-rfkill.c
@@ -1,0 +1,186 @@
+/*
+ *
+ *  Connection Manager
+ *
+ *  Copyright (C) 2014 Jolla Ltd.
+ *  Contact: Hannu Mallat <hannu.mallat@jollamobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/*
+ * Ensure that rfkill is set to desired state on startup for
+ * Bluetooth, even before bluetooth legacy driver figures out BT
+ * adapter presence via BlueZ D-Bus API.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <gdbus.h>
+
+#define CONNMAN_API_SUBJECT_TO_CHANGE
+#include "connman.h"
+
+#define BLUETOOTH_RFKILL_IDENT "bluetooth_rfkill"
+
+static struct connman_device *bt_device = NULL;
+
+#define BT_DEVICE 0
+
+static int bluetooth_rfkill_device_probe(struct connman_device *device)
+{
+	struct hci_dev_info dev_info;
+	int fd = -1;
+	int r = 0;
+
+	DBG("device %p", device);
+
+	fd = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
+	if (fd < 0) {
+		DBG("Cannot open BT socket: %s(%d)", strerror(errno), errno);
+		r = -errno;
+		goto out;
+	}
+
+	memset(&dev_info, 0, sizeof(dev_info));
+	dev_info.dev_id = BT_DEVICE;
+	if (ioctl(fd, HCIGETDEVINFO, &dev_info) < 0) {
+		DBG("Cannot get BT info: %s(%d)", strerror(errno), errno);
+		r = -errno;
+		goto out;
+	}
+
+	if (ioctl(fd, HCIDEVUP, dev_info.dev_id) < 0) {
+		DBG("Cannot raise BT dev %d: %s(%d)", dev_info.dev_id,
+					strerror(errno), errno);
+		if (errno != ERFKILL && errno != EALREADY) {
+			r = -errno;
+			goto out;
+		}
+	}
+
+	DBG("Probe done.");
+
+out:
+	if (fd >= 0)
+		close(fd);
+
+	return r;
+}
+
+static void bluetooth_rfkill_device_remove(struct connman_device *device)
+{
+	DBG("device %p", device);
+}
+
+static int bluetooth_rfkill_device_enable(struct connman_device *device)
+{
+	DBG("device %p", device);
+	return 0;
+}
+
+static int bluetooth_rfkill_device_disable(struct connman_device *device)
+{
+	DBG("device %p", device);
+	return 0;
+}
+
+static struct connman_device_driver dev_driver = {
+	.name = "bluetooth_rfkill",
+	.type = CONNMAN_DEVICE_TYPE_BLUETOOTH,
+	.probe = bluetooth_rfkill_device_probe,
+	.remove = bluetooth_rfkill_device_remove,
+	.enable = bluetooth_rfkill_device_enable,
+	.disable = bluetooth_rfkill_device_disable
+};
+
+static int bluetooth_rfkill_tech_probe(struct connman_technology *technology)
+{
+	DBG("technology %p", technology);
+	__connman_rfkill_block(CONNMAN_SERVICE_TYPE_BLUETOOTH, TRUE);
+	return 0;
+}
+
+static void bluetooth_rfkill_tech_remove(struct connman_technology *technology)
+{
+	DBG("technology %p", technology);
+}
+
+static struct connman_technology_driver tech_driver = {
+	.name = "bluetooth_rfkill",
+	.type = CONNMAN_SERVICE_TYPE_BLUETOOTH,
+	.probe = bluetooth_rfkill_tech_probe,
+	.remove = bluetooth_rfkill_tech_remove,
+};
+
+static int jolla_rfkill_init(void)
+{
+	int err;
+
+	DBG("Initializing dummy device for BT rfkill.");
+
+	err = connman_device_driver_register(&dev_driver);
+	if (err < 0)
+		return err;
+
+	err = connman_technology_driver_register(&tech_driver);
+	if (err < 0) {
+		connman_device_driver_unregister(&dev_driver);
+		return err;
+	}
+
+	/* Force loading of BT settings and applying BT rfkill */
+	bt_device = connman_device_create("bluetooth_rfkill",
+					CONNMAN_DEVICE_TYPE_BLUETOOTH);
+	if (bt_device != NULL) {
+		connman_device_set_ident(bt_device, BLUETOOTH_RFKILL_IDENT);
+		if (connman_device_register(bt_device) < 0) {
+                       connman_device_unref(bt_device);
+                       connman_technology_driver_unregister(&tech_driver);
+                       connman_device_driver_unregister(&dev_driver);
+                       return err;
+               }
+       }
+
+	return 0;
+}
+
+static void jolla_rfkill_exit(void)
+{
+	DBG("");
+
+	if (bt_device != NULL) {
+		connman_device_unregister(bt_device);
+		connman_device_unref(bt_device);
+		bt_device = NULL;
+	}
+
+	connman_technology_driver_unregister(&tech_driver);
+	connman_device_driver_unregister(&dev_driver);
+}
+
+CONNMAN_PLUGIN_DEFINE(jolla_rfkill, "Jolla rfkill", VERSION, CONNMAN_PLUGIN_PRIORITY_DEFAULT,
+                      jolla_rfkill_init, jolla_rfkill_exit)

--- a/connman/src/connman.service.in
+++ b/connman/src/connman.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Connection service
-Requires=dbus.socket
-After=dbus.socket
+Requires=@CONNMAN_SERVICE_REQUIRES@
+After=@CONNMAN_SERVICE_AFTER@
 Before=remote-fs.target
 
 [Service]

--- a/connman/src/main.c
+++ b/connman/src/main.c
@@ -732,8 +732,10 @@ int main(int argc, char *argv[])
 
 #ifdef SYSTEMD
 	/* Tell systemd that we have started up */
-	if( option_systemd )
+	if( option_systemd ) {
+		DBG("Notifying systemd.");
 		sd_notify(0, "READY=1");
+	}
 #endif
 
 	g_main_loop_run(main_loop);

--- a/rpm/connman.spec
+++ b/rpm/connman.spec
@@ -16,6 +16,7 @@ Requires:   pacrunner
 Requires:   connman-configs
 Requires:   systemd
 Requires:   libiphb
+Requires:   bluez-libs
 Requires(preun): systemd
 Requires(post): systemd
 Requires(postun): systemd
@@ -29,6 +30,7 @@ BuildRequires:  openvpn
 BuildRequires:  readline-devel
 BuildRequires:  pkgconfig(libsystemd-daemon)
 BuildRequires:  libiphb-devel
+BuildRequires:  bluez-libs-devel
 
 %description
 Connection Manager provides a daemon for managing Internet connections
@@ -105,6 +107,7 @@ Documentation for connman.
     --enable-pacrunner=builtin \
     --enable-jolla-gps=builtin \
     --enable-jolla-wakeup-timer=builtin \
+    --enable-jolla-rfkill=builtin \
     --enable-client \
     --enable-test \
     --with-systemdunitdir=/%{_lib}/systemd/system \
@@ -132,10 +135,12 @@ cp -a %{SOURCE2} %{buildroot}%{_sysconfdir}/connman/
 
 mkdir -p %{buildroot}/%{_lib}/systemd/system/network.target.wants
 ln -s ../connman.service %{buildroot}/%{_lib}/systemd/system/network.target.wants/connman.service
+ln -s ../jolla-rfkill-hciwait.service %{buildroot}/%{_lib}/systemd/system/network.target.wants/jolla-rfkill-hciwait.service
 
 %preun
 if [ "$1" -eq 0 ]; then
 systemctl stop connman.service || :
+systemctl stop jolla-rfkill-hciwait.service || :
 fi
 
 %post
@@ -157,6 +162,8 @@ systemctl daemon-reload || :
 /%{_lib}/systemd/system/network.target.wants/connman.service
 /%{_lib}/systemd/system/connman-vpn.service
 %{_datadir}/dbus-1/system-services/net.connman.vpn.service
+/%{_lib}/systemd/system/jolla-rfkill-hciwait.service
+/%{_lib}/systemd/system/network.target.wants/jolla-rfkill-hciwait.service
 
 %files devel
 %defattr(-,root,root,-)


### PR DESCRIPTION
The bluetooth_legacy plugin only registers a bluetooth device when
bluetoothd has started up and indicated that an adapter is present;
and only at that time will connman set BT rfkill according to saved
settings.

This means that the intended behaviour of having connmand start before
bluetoothd and have rfkill set up before BT adapter is accessed does
not work. By implementing a dummy bluetooth driver we can initialize
bluetooth technology in connman and set rfkill to desired value
actually before bluetoothd starts up.

As a prerequisite, connmand has to wait for a HCI adapter to be present
in the system; otherwise setting up rfkill for BT won't work. This is
achieved by implementing a service that waits for an adapter to appear
outside connmand.

[connman] plugins: Dummy bluetooth plugin for rfkill setup
