### PR TITLE
ipconfig: Do not pass a NULL pointer to D-Bus

### DIFF
--- a/connman/src/inet.c
+++ b/connman/src/inet.c
@@ -231,11 +231,15 @@ char *connman_inet_ifname(int index)
 	ifr.ifr_ifindex = index;
 
 	err = ioctl(sk, SIOCGIFNAME, &ifr);
+	if (err < 0)
+		err = -errno;
 
 	close(sk);
 
-	if (err < 0)
+	if (err < 0) {
+		connman_error("%s: %s", __func__, strerror(-err));
 		return NULL;
+	}
 
 	return g_strdup(ifr.ifr_name);
 }

--- a/connman/src/ipconfig.c
+++ b/connman/src/ipconfig.c
@@ -2166,9 +2166,11 @@ void __connman_ipconfig_append_ethernet(struct connman_ipconfig *ipconfig,
 
 	if (ipconfig->index >= 0) {
 		char *ifname = connman_inet_ifname(ipconfig->index);
-		connman_dbus_dict_append_basic(iter, "Interface",
-					DBUS_TYPE_STRING, &ifname);
-		g_free(ifname);
+		if (ifname) {
+			connman_dbus_dict_append_basic(iter, "Interface",
+						DBUS_TYPE_STRING, &ifname);
+			g_free(ifname);
+		}
 	}
 
 	if (ipdevice->address)


### PR DESCRIPTION
connman_inet_ifname() may return a NULL pointer e.g. if the interface
does not exist in the kernel anymore but connman isn't yet aware of
that. Passing a NULL pointer to D-Bus may result in an abort, so check
the return value.

[connman] ipconfig: Do not pass a NULL pointer to D-Bus
