### PR TITLE
Check for NULL argument in __connman_ipconfig_ipv6_reset_privacy

### DIFF
--- a/connman/src/ipconfig.c
+++ b/connman/src/ipconfig.c
@@ -1779,6 +1779,9 @@ int __connman_ipconfig_ipv6_reset_privacy(struct connman_ipconfig *ipconfig)
 	struct connman_ipdevice *ipdevice;
 	int err;
 
+	if (!ipconfig)
+		return -EINVAL;
+
 	ipdevice = g_hash_table_lookup(ipdevice_hash,
 						GINT_TO_POINTER(ipconfig->index));
 	if (!ipdevice)


### PR DESCRIPTION
Since callers don't check it for NULL, then the function should.
