### PR TITLE
[connman] Fix GSource allocation, wakeup timer execution

### DIFF
--- a/connman/Makefile.am
+++ b/connman/Makefile.am
@@ -255,7 +255,8 @@ client_connmanctl_LDADD = gdbus/libgdbus-internal.la @DBUS_LIBS@ @GLIB_LIBS@ \
 				-lreadline -ldl
 endif
 
-noinst_PROGRAMS += unit/test-pbkdf2-sha1 unit/test-prf-sha1 unit/test-ippool
+noinst_PROGRAMS += unit/test-pbkdf2-sha1 unit/test-prf-sha1 unit/test-ippool \
+			unit/test-jolla-wakeup-timer
 
 unit_test_pbkdf2_sha1_SOURCES = unit/test-pbkdf2-sha1.c \
 				src/shared/sha1.h src/shared/sha1.c
@@ -269,7 +270,13 @@ unit_test_ippool_SOURCES = src/log.c src/dbus.c src/ippool.c unit/test-ippool.c
 unit_test_ippool_LDADD = gdbus/libgdbus-internal.la \
 				@GLIB_LIBS@ @DBUS_LIBS@ -ldl
 
-TESTS = unit/test-pbkdf2-sha1 unit/test-prf-sha1 unit/test-ippool
+unit_test_jolla_wakeup_timer_SOURCES = unit/test-jolla-wakeup-timer.c \
+				src/log.c src/wakeup_timer.c \
+				plugins/jolla_wakeup_timer.c
+unit_test_jolla_wakeup_timer_LDADD = @GLIB_LIBS@ @IPHB_LIBS@ -lrt -ldl
+
+TESTS = unit/test-pbkdf2-sha1 unit/test-prf-sha1 unit/test-ippool \
+		unit/test-jolla-wakeup-timer
 
 if WISPR
 noinst_PROGRAMS += tools/wispr

--- a/connman/unit/test-jolla-wakeup-timer.c
+++ b/connman/unit/test-jolla-wakeup-timer.c
@@ -1,0 +1,115 @@
+/*
+ *
+ *  Connection Manager
+ *
+ *  Copyright (C) 2014 Jolla Ltd. All rights reserved.
+ *  Contact: Hannu Mallat <hannu.mallat@jollamobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <glib.h>
+
+#define CONNMAN_API_SUBJECT_TO_CHANGE
+#include "plugin.h"
+#include "wakeup_timer.h"
+
+#define CHUNK 4
+#define MAX_COUNT 100
+#define MAX_DELAY 20
+
+static GMainLoop *main_loop = NULL;
+
+extern struct connman_plugin_desc __connman_builtin_jolla_wakeup_timer;
+
+extern int __connman_log_init(const char *program, const char *debug,
+			gboolean detach, gboolean backtrace,
+			const char *program_name, const char *program_version);
+
+static unsigned int timeouts_scheduled;
+static unsigned int timeouts_handled;
+
+static gboolean create_timeout_within_callback_cb(gpointer user_data)
+{
+	int i;
+
+	DBG("scheduled %d, handled %d", timeouts_scheduled, timeouts_handled);
+
+	for (i = 0; i < CHUNK && timeouts_scheduled < MAX_COUNT; i++) {
+		timeouts_scheduled++;
+		connman_wakeup_timer(G_PRIORITY_DEFAULT,
+				g_test_rand_int_range(0, MAX_DELAY),
+				create_timeout_within_callback_cb,
+				NULL,
+				NULL);
+	}
+
+	timeouts_handled++;
+	if (timeouts_handled == MAX_COUNT) {
+		DBG("Done, let's quit");
+		g_main_loop_quit(main_loop);
+	}
+
+	return FALSE;
+}
+
+static gboolean create_timeout_within_callback_seed(gpointer user_data)
+{
+	int i;
+
+	for (i = 0; i < CHUNK && timeouts_scheduled < MAX_COUNT; i++) {
+		timeouts_scheduled++;
+		connman_wakeup_timer(G_PRIORITY_DEFAULT,
+				g_test_rand_int_range(0, MAX_DELAY),
+				create_timeout_within_callback_cb,
+				NULL,
+				NULL);
+	}
+
+	return FALSE;
+}
+
+static void create_timeout_within_callback(void)
+{
+	timeouts_scheduled = 0;
+	timeouts_handled = 0;
+
+	main_loop = g_main_loop_new(NULL, FALSE);
+	__connman_log_init("test-jolla-wakeup-timer",
+				g_test_verbose() ? "*" : NULL,
+				FALSE, FALSE,
+				"test-jolla-wakeup-timer", "1");
+	(__connman_builtin_jolla_wakeup_timer.init)();
+
+	g_timeout_add(0, create_timeout_within_callback_seed, NULL);
+	g_main_loop_run(main_loop);
+
+	(__connman_builtin_jolla_wakeup_timer.exit)();
+	g_main_loop_unref(main_loop);
+}
+
+int main(int argc, char *argv[])
+{
+	g_test_init(&argc, &argv, NULL);
+
+	g_test_add_func("/wakeup-timer/create-timeout-within-callback",
+			create_timeout_within_callback);
+
+	return g_test_run();
+}


### PR DESCRIPTION
Do not execute a wakeup timer with zero timeout from within the
function that adds the timeout; otherwise a one-shot timer would get
removed before source ID is returned to the caller.

Also, completely free dummy GSource when it's cleaned up.

Created a unit test application for wakeup timers; added a test case
for exercising connman_wakeup_timer().
