### PR TITLE
gsupplicant: Add property calls to property_calls list

### DIFF
--- a/connman/gsupplicant/dbus.c
+++ b/connman/gsupplicant/dbus.c
@@ -240,6 +240,8 @@ int supplicant_dbus_property_get_all(const char *path, const char *interface,
 	property_call->function = function;
 	property_call->user_data = user_data;
 
+	property_calls = g_slist_prepend(property_calls, property_call);
+
 	dbus_pending_call_set_notify(call, property_get_all_reply,
 				property_call, property_call_free);
 
@@ -326,6 +328,8 @@ int supplicant_dbus_property_get(const char *path, const char *interface,
 	property_call->pending_call = call;
 	property_call->function = function;
 	property_call->user_data = user_data;
+
+	property_calls = g_slist_prepend(property_calls, property_call);
 
 	dbus_pending_call_set_notify(call, property_get_reply,
 					property_call, property_call_free);
@@ -418,6 +422,8 @@ int supplicant_dbus_property_set(const char *path, const char *interface,
 	property_call->pending_call = call;
 	property_call->function = function;
 	property_call->user_data = user_data;
+
+	property_calls = g_slist_prepend(property_calls, property_call);
 
 	dbus_pending_call_set_notify(call, property_set_reply,
 					property_call, property_call_free);


### PR DESCRIPTION
Although the logic for handling property call list was available, the
property call list was not being populated.
