### PR TITLE
[connman] Fix dnsproxy unit test non-optimized compilation

### DIFF
--- a/connman/Makefile.am
+++ b/connman/Makefile.am
@@ -276,7 +276,7 @@ unit_test_jolla_wakeup_timer_SOURCES = unit/test-jolla-wakeup-timer.c \
 unit_test_jolla_wakeup_timer_LDADD = @GLIB_LIBS@ -lrt -ldl
 
 unit_test_dnsproxy_SOURCES = unit/test-dnsproxy.c src/log.c
-unit_test_dnsproxy_LDADD = @GLIB_LIBS@ -ldl
+unit_test_dnsproxy_LDADD = @GLIB_LIBS@ -lresolv -ldl
 
 TESTS = unit/test-pbkdf2-sha1 unit/test-prf-sha1 unit/test-ippool \
 		unit/test-jolla-wakeup-timer unit/test-dnsproxy

--- a/connman/unit/test-dnsproxy.c
+++ b/connman/unit/test-dnsproxy.c
@@ -78,12 +78,44 @@ int socket(int domain, int type, int protocol)
 	return -1;
 }
 
+GResolv *g_resolv_new(int index)
+{
+	return NULL;
+}
+
+bool g_resolv_set_address_family(GResolv *resolv, int family)
+{
+	return FALSE;
+}
+
+bool g_resolv_add_nameserver(GResolv *resolv, const char *address,
+					uint16_t port, unsigned long flags)
+{
+	return FALSE;
+}
+
+guint g_resolv_lookup_hostname(GResolv *resolv, const char *hostname,
+				GResolvResultFunc func, gpointer user_data)
+{
+	return 0;
+}
+
 int __connman_agent_request_connection(void *user_data)
 {
 	return -1;
 }
 
+char *connman_inet_ifname(int index)
+{
+	return NULL;
+}
+
 int connman_inet_ifindex(const char *name)
+{
+	return -1;
+}
+
+int __connman_inet_get_interface_address(int index, int family, void *address)
 {
 	return -1;
 }


### PR DESCRIPTION
With the default optimized compilation the compiler doesn't include
functions that aren't used into the binary, and their dependencies
aren't needed; with non-optimized compilation additional stubs are
needed to link the unit test even if those functions aren't used.
