### PR TITLE
[connman] Fix tethering and access to freed memory

### DIFF
--- a/connman/gsupplicant/supplicant.c
+++ b/connman/gsupplicant/supplicant.c
@@ -3055,7 +3055,7 @@ int g_supplicant_interface_remove(GSupplicantInterface *interface,
 						"RemoveInterface",
 						interface_remove_params,
 						interface_remove_result, data,
-						interface);
+						NULL);
 	if (ret < 0) {
 		g_free(data->path);
 		dbus_free(data);


### PR DESCRIPTION
Previous fix of accessing freed memory during tethering broke it;
reworked the code so that tethering_info wifi pointer gets cleared
if wifi device is removed during pending D-Bus method call, and
tethering callbacks check for pointer value.
