### PR TITLE
Refactored counters

### DIFF
--- a/connman/Makefile.am
+++ b/connman/Makefile.am
@@ -103,10 +103,10 @@ src_connmand_SOURCES = $(gdhcp_sources) $(gweb_sources) \
 			src/storage.c src/dbus.c src/config.c \
 			src/technology.c src/counter.c src/ntp.c \
 			src/session.c src/tethering.c src/wpad.c src/wispr.c \
-			src/stats.c src/iptables.c src/dnsproxy.c src/6to4.c \
+			src/iptables.c src/dnsproxy.c src/6to4.c \
 			src/ippool.c src/bridge.c src/nat.c src/ipaddress.c \
 			src/inotify.c src/firewall.c src/ipv6pd.c src/peer.c \
-			src/wakeup_timer.c
+			src/wakeup_timer.c src/jolla-stats.c
 
 src_connmand_LDADD = gdbus/libgdbus-internal.la $(builtin_libadd) \
 			@GLIB_LIBS@ @DBUS_LIBS@ @XTABLES_LIBS@ @GNUTLS_LIBS@ \

--- a/connman/configure.ac
+++ b/connman/configure.ac
@@ -411,13 +411,6 @@ AM_CONDITIONAL(VPN, test "${enable_openconnect}" != "no" -o \
 			"${enable_l2tp}" != "no" -o \
 			"${enable_pptp}" != "no")
 
-AC_ARG_ENABLE(counter-wraparound, AC_HELP_STRING([--enable-counter-wraparound],
-			[enable checking 32-bit statistics counter wraparound]), [
-	if (test "${enableval}" = "yes" ); then
-		CFLAGS="$CFLAGS -DCOUNTER_WRAPAROUND_AT_32BIT"
-	fi
-])
-
 AC_OUTPUT(Makefile include/version.h src/connman.service
 		vpn/connman-vpn.service	vpn/net.connman.vpn.service
 		scripts/connman	connman.pc src/net.connman.service)

--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -295,6 +295,17 @@ struct connman_ipconfig_ops {
 	void (*route_unset) (struct connman_ipconfig *ipconfig, const char *ifname);
 };
 
+struct connman_stats_data {
+	uint64_t rx_packets;
+	uint64_t tx_packets;
+	uint64_t rx_bytes;
+	uint64_t tx_bytes;
+	uint64_t rx_errors;
+	uint64_t tx_errors;
+	uint64_t rx_dropped;
+	uint64_t tx_dropped;
+};
+
 struct connman_ipconfig *__connman_ipconfig_create(int index,
 					enum connman_ipconfig_type type);
 
@@ -314,6 +325,8 @@ void *__connman_ipconfig_get_data(struct connman_ipconfig *ipconfig);
 void __connman_ipconfig_set_data(struct connman_ipconfig *ipconfig, void *data);
 
 int __connman_ipconfig_get_index(struct connman_ipconfig *ipconfig);
+gboolean __connman_ipconfig_get_stats(struct connman_ipconfig *ipconfig,
+				struct connman_stats_data *stats);
 
 void __connman_ipconfig_set_ops(struct connman_ipconfig *ipconfig,
 				const struct connman_ipconfig_ops *ops);
@@ -779,10 +792,7 @@ int __connman_service_reset_ipconfig(struct connman_service *service,
 		enum connman_service_state *new_state);
 
 void __connman_service_notify(struct connman_service *service,
-			uint64_t rx_packets, uint64_t tx_packets,
-			uint64_t rx_bytes, uint64_t tx_bytes,
-			uint64_t rx_error, uint64_t tx_error,
-			uint64_t rx_dropped, uint64_t tx_dropped);
+			const struct connman_stats_data *data);
 
 int __connman_service_counter_register(const char *counter);
 void __connman_service_counter_unregister(const char *counter);
@@ -852,27 +862,20 @@ int __connman_session_destroy(DBusMessage *msg);
 int __connman_session_init(void);
 void __connman_session_cleanup(void);
 
-struct connman_stats_data {
-        uint64_t rx_packets;
-        uint64_t tx_packets;
-        uint64_t rx_bytes;
-        uint64_t tx_bytes;
-        uint64_t rx_errors;
-        uint64_t tx_errors;
-        uint64_t rx_dropped;
-        uint64_t tx_dropped;
-        unsigned int time;
-};
-
 int __connman_stats_init(void);
 void __connman_stats_cleanup(void);
-int __connman_stats_service_register(struct connman_service *service);
-void __connman_stats_service_unregister(struct connman_service *service);
-int  __connman_stats_update(struct connman_service *service,
-				bool roaming,
-				struct connman_stats_data *data);
-int __connman_stats_get(struct connman_service *service,
-				bool roaming,
+
+struct connman_stats *__connman_stats_new(const char *identifier,
+							gboolean roaming);
+struct connman_stats *__connman_stats_new_existing(const char *identifier,
+							gboolean roaming);
+void __connman_stats_free(struct connman_stats *stats);
+void __connman_stats_reset(struct connman_stats *stats);
+void __connman_stats_update(struct connman_stats *stats,
+				const struct connman_stats_data *data);
+void __connman_stats_rebase(struct connman_stats *stats,
+				const struct connman_stats_data *data);
+void __connman_stats_get(struct connman_stats *stats,
 				struct connman_stats_data *data);
 
 int __connman_iptables_dump(const char *table_name);

--- a/connman/src/jolla-stats.c
+++ b/connman/src/jolla-stats.c
@@ -1,0 +1,333 @@
+/*
+ *
+ *  Connection Manager
+ *
+ *  Copyright (C) 2014 Jolla Ltd. All rights reserved.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+#include "connman.h"
+
+/*
+ * Simplified version of stats.c
+ */
+
+#define STATS_DIR_MODE      (0755)
+#define STATS_FILE_MODE     (0644)
+#define STATS_FILE_VERSION  (0x01)
+#define STATS_FILE_SIZE     sizeof(struct stats_file_contents)
+#define STATS_FILE_HOME     "stats.home"
+#define STATS_FILE_ROAMING  "stats.roaming"
+
+#define stats_file(roaming) ((roaming) ? STATS_FILE_ROAMING : STATS_FILE_HOME)
+
+/* Unused files that may have been created by earlier versions of connman */
+static const char* stats_obsolete[] = { "data", "history" };
+
+struct stats_file_contents {
+	uint32_t version;
+	uint32_t reserved;
+	struct connman_stats_data total;
+} __attribute__((packed));
+
+struct connman_stats {
+	int fd;
+	char *path;
+	char *name;
+	struct stats_file_contents *contents;
+	struct connman_stats_data last;
+};
+
+static void stats_init_contents(struct connman_stats *stats)
+{
+	if (stats->contents->version != STATS_FILE_VERSION) {
+		DBG("%s", stats->name);
+		memset(stats->contents, 0, STATS_FILE_SIZE);
+		stats->contents->version = STATS_FILE_VERSION;
+	}
+}
+
+static struct connman_stats *stats_file_open(const char *id, const char *dir,
+					const char *file, gboolean create)
+{
+        const int flags = O_RDWR | O_CLOEXEC | (create ? O_CREAT : 0);
+	char* path = g_strconcat(dir, "/", file, NULL);
+	int fd = open(path, flags, STATS_FILE_MODE);
+	if (fd >= 0) {
+		int err = ftruncate(fd, STATS_FILE_SIZE);
+		if (err >= 0) {
+			struct connman_stats *stats;
+
+			stats = g_new0(struct connman_stats, 1);
+			stats->contents = mmap(NULL, STATS_FILE_SIZE,
+				PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+			if (stats->contents != MAP_FAILED) {
+				/* Success */
+				DBG("%s", path);
+				DBG("[RX] %llu packets %llu bytes",
+					stats->contents->total.rx_packets,
+					stats->contents->total.rx_bytes);
+				DBG("[TX] %llu packets %llu bytes",
+					stats->contents->total.tx_packets,
+					stats->contents->total.tx_bytes);
+
+				stats->fd = fd;
+				stats->path = path;
+				stats->name = g_strconcat(id, "/", file, NULL);
+				stats_init_contents(stats);
+				return stats;
+			}
+			connman_error("mmap %s error: %s", path,
+				strerror(errno));
+			g_free(stats);
+		} else {
+			connman_error("ftrunctate %s error: %s", path,
+				strerror(errno));
+		}
+		close(fd);
+	}
+	/* Error */
+	g_free(path);
+	return NULL;
+}
+
+/** Deletes the leftovers from the old connman */
+static void stats_delete_obsolete_files(const char* dir)
+{
+	int i;
+	for (i=0; i<G_N_ELEMENTS(stats_obsolete); i++) {
+		char* path = g_strconcat(dir, "/", stats_obsolete[i], NULL);
+		if (unlink(path) < 0) {
+			if (errno != ENOENT) {
+				connman_error("error deleting %s: %s",
+						path, strerror(errno));
+			}
+		} else {
+			DBG("deleted %s", path);
+		}
+		g_free(path);
+	}
+}
+
+/** Creates file if it doesn't exist */
+struct connman_stats *__connman_stats_new(const char *ident, gboolean roaming)
+{
+	int err = 0;
+	struct connman_stats *stats = NULL;
+	char *dir = g_strconcat(STORAGEDIR, "/", ident, NULL);
+
+	DBG("%s %d", ident, roaming);
+
+	/* If the dir doesn't exist, create it */
+	if (!g_file_test(dir, G_FILE_TEST_IS_DIR)) {
+		if (mkdir(dir, STATS_DIR_MODE) < 0) {
+			if (errno != EEXIST) {
+				err = -errno;
+			}
+		}
+	}
+
+	if (!err) {
+		stats = stats_file_open(ident, dir, stats_file(roaming), true);
+		stats_delete_obsolete_files(dir);
+	} else {
+		connman_error("failed to create %s: %s", dir, strerror(errno));
+	}
+
+	g_free(dir);
+	return stats;
+}
+
+/** Returns NULL if the file doesn't exist */
+struct connman_stats *__connman_stats_new_existing(const char *identifier,
+							gboolean roaming)
+{
+	char *dir = g_strconcat(STORAGEDIR, "/", identifier, NULL);
+	struct connman_stats *stats;
+
+	stats = stats_file_open(identifier, dir, stats_file(roaming), false);
+	g_free(dir);
+	return stats;
+}
+
+void __connman_stats_free(struct connman_stats *stats)
+{
+	if (stats) {
+		DBG("%s", stats->name);
+		msync(stats->contents, STATS_FILE_SIZE, MS_SYNC);
+		munmap(stats->contents, STATS_FILE_SIZE);
+		close(stats->fd);
+		g_free(stats->path);
+		g_free(stats->name);
+		g_free(stats);
+	}
+}
+
+/* Protection against counters getting wrapped at 32-bit boundary */
+#define STATS_UPPER_BITS_SHIFT (32)
+#define STATS_UPPER_BITS (~((1ull << STATS_UPPER_BITS_SHIFT) - 1))
+#define stats_32bit(value) (((value) & STATS_UPPER_BITS) == 0)
+
+static inline void stats_fix32(uint64_t *newval, uint64_t oldval)
+{
+	if (*newval < oldval) {
+		uint64_t prev = *newval;
+		*newval |= (oldval & STATS_UPPER_BITS);
+
+		if (G_UNLIKELY(*newval < oldval))
+			*newval += (1ull << STATS_UPPER_BITS_SHIFT);
+
+		DBG("0x%08llx -> 0x%llx", prev, *newval);
+	}
+}
+
+void __connman_stats_update(struct connman_stats *stats,
+				const struct connman_stats_data *data)
+{
+	struct connman_stats_data *last, *total;
+	struct connman_stats_data fixed;
+
+	if (!stats)
+		return;
+
+	last = &stats->last;
+	total = &stats->contents->total;
+
+	/* If nothing has changed, avoid overwriting the last data
+	 * to reduce the number of writes to the file */
+	if (!memcmp(last, data, sizeof(*last)))
+		return;
+
+	if ((data->rx_packets < last->rx_packets) ||
+	    (data->tx_packets < last->tx_packets) ||
+	    (data->rx_bytes   < last->rx_bytes  ) ||
+	    (data->tx_bytes   < last->tx_bytes  ) ||
+	    (data->rx_errors  < last->rx_errors ) ||
+	    (data->tx_errors  < last->tx_errors ) ||
+	    (data->rx_dropped < last->rx_dropped) ||
+	    (data->tx_dropped < last->tx_dropped)) {
+
+		/*
+		 * This can happen if the counter wasn't rebased after
+		 * switching the network interface. However most likely
+		 * it's the result of 32-bit wrap-around that occurs in
+		 * (at least some versions of) 32-bit kernels. Double
+		 * check that all the upper 32-bits in all counters are
+		 * indeed zero.
+		 */
+
+		if (G_UNLIKELY(!stats_32bit(data->rx_packets)) ||
+		    G_UNLIKELY(!stats_32bit(data->tx_packets)) ||
+		    G_UNLIKELY(!stats_32bit(data->rx_bytes  )) ||
+		    G_UNLIKELY(!stats_32bit(data->tx_bytes  )) ||
+		    G_UNLIKELY(!stats_32bit(data->rx_errors )) ||
+		    G_UNLIKELY(!stats_32bit(data->tx_errors )) ||
+		    G_UNLIKELY(!stats_32bit(data->rx_dropped)) ||
+		    G_UNLIKELY(!stats_32bit(data->tx_dropped))) {
+			DBG("%s screwed up", stats->name);
+			return;
+		}
+
+		fixed = *data;
+		data = &fixed;
+
+		stats_fix32(&fixed.rx_packets, last->rx_packets);
+		stats_fix32(&fixed.tx_packets, last->tx_packets);
+		stats_fix32(&fixed.rx_bytes,   last->rx_bytes  );
+		stats_fix32(&fixed.tx_bytes,   last->tx_bytes  );
+		stats_fix32(&fixed.rx_errors,  last->rx_errors );
+		stats_fix32(&fixed.tx_errors,  last->tx_errors );
+		stats_fix32(&fixed.rx_dropped, last->rx_dropped);
+		stats_fix32(&fixed.tx_dropped, last->tx_dropped);
+	}
+
+	DBG("%s [RX] %llu packets %llu bytes", stats->name,
+					data->rx_packets, data->rx_bytes);
+	DBG("%s [TX] %llu packets %llu bytes", stats->name,
+					data->tx_packets, data->tx_bytes);
+
+	/* Update the total counters */
+	total->rx_packets += (data->rx_packets - last->rx_packets);
+	total->tx_packets += (data->tx_packets - last->tx_packets);
+	total->rx_bytes   += (data->rx_bytes   - last->rx_bytes  );
+	total->tx_bytes   += (data->tx_bytes   - last->tx_bytes  );
+	total->rx_errors  += (data->rx_errors  - last->rx_errors );
+	total->tx_errors  += (data->tx_errors  - last->tx_errors );
+	total->rx_dropped += (data->rx_dropped - last->rx_dropped);
+	total->tx_dropped += (data->tx_dropped - last->tx_dropped);
+
+	/* Store the last values */
+	*last = *data;
+}
+
+void __connman_stats_reset(struct connman_stats *stats)
+{
+	if (stats) {
+		struct connman_stats_data* total = &stats->contents->total;
+
+		DBG("%s", stats->name);
+		memset(total, 0, sizeof(*total));
+	}
+}
+
+void __connman_stats_rebase(struct connman_stats *stats,
+				const struct connman_stats_data *data)
+{
+	if (stats) {
+		struct connman_stats_data* last = &stats->last;
+
+		if (data) {
+			DBG("%s [RX] %llu packets %llu bytes", stats->name,
+					data->rx_packets, data->rx_bytes);
+			DBG("%s [TX] %llu packets %llu bytes", stats->name,
+					data->tx_packets, data->tx_bytes);
+			*last = *data;
+		} else {
+			DBG("%s", stats->name);
+			memset(last, 0, sizeof(*last));
+		}
+	}
+}
+
+void __connman_stats_get(struct connman_stats *stats,
+				struct connman_stats_data *data)
+{
+	if (stats) {
+		*data = stats->contents->total;
+	} else {
+		bzero(data, sizeof(*data));
+	}
+}
+
+int __connman_stats_init(void)
+{
+	return 0;
+}
+
+void __connman_stats_cleanup(void)
+{
+}

--- a/rpm/connman.spec
+++ b/rpm/connman.spec
@@ -109,7 +109,6 @@ Documentation for connman.
     --enable-test \
     --with-systemdunitdir=/%{_lib}/systemd/system \
     --enable-systemd \
-    --enable-counter-wraparound
 
 make %{?jobs:-j%jobs}
 


### PR DESCRIPTION
1. Replaced stats.c with jolla-stats.c which isn't doing anything we don't need. The new implementation is much smaller and simpler. It also eliminates the global hashtable which served the purpose of associating service with stats - now it's done using a pointer. Roaming and home statistics are separated from each other.
2. Fixed the problem with service being notified about the counter changes for a wrong interface. The cellular service may be associated with different interfaces over time. In practice it's ether rmnet0 or rmnet1, depending on MMS context activity and whether or not one of those interfaces was up when connman started (when it crashes, ofono interfaces stay up).
