### PR TITLE
[connman] Check for pointer validity before cancelling agent request

### DIFF
--- a/connman/src/agent.c
+++ b/connman/src/agent.c
@@ -166,6 +166,9 @@ static int send_cancel_request(struct connman_agent *agent,
 {
 	DBusMessage *message;
 
+	if (!request->driver)
+		return 0;
+
 	DBG("send cancel req to %s %s", agent->owner, agent->path);
 
 	message = dbus_message_new_method_call(agent->owner,


### PR DESCRIPTION
In the case where agent disappears from D-Bus while there are pending
requests, request->driver may become null. As it's useless to send a
Cancel to a nonexistent agent, not to mention accessing null pointer
causes a crash, check for the pointer value before creating a D-Bus
message.
