### PR TITLE
[connman] Enable TLSv1.2 and TLSv1.1 with gweb

### DIFF
--- a/connman/gweb/giognutls.c
+++ b/connman/gweb/giognutls.c
@@ -456,7 +456,8 @@ GIOChannel *g_io_channel_gnutls_new(int fd)
 						"NORMAL:%COMPAT", NULL);
 #else
 	gnutls_priority_set_direct(gnutls_channel->session,
-		"NORMAL:-VERS-TLS-ALL:+VERS-TLS1.0:+VERS-SSL3.0:%COMPAT", NULL);
+		"NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2:+VERS-TLS1.1:" \
+			"+VERS-TLS1.0:+VERS-SSL3.0:%COMPAT", NULL);
 #endif
 
 	gnutls_certificate_allocate_credentials(&gnutls_channel->cred);


### PR DESCRIPTION
Both TLS1.2 and TLS1.1 should be enabled for secure access.
