### PR TITLE
[connman] fix memory access error when send "Hidden" to dbus

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -2497,8 +2497,9 @@ static void append_properties(DBusMessageIter *dict, dbus_bool_t limited,
 		connman_dbus_dict_append_dict(dict, "Ethernet",
 						append_ethernet, service);
 
+        val = service->hidden_service;
         connman_dbus_dict_append_basic(dict, "Hidden",
-                        DBUS_TYPE_BOOLEAN, &service->hidden_service);
+                        DBUS_TYPE_BOOLEAN, &val);
         break;
 	case CONNMAN_SERVICE_TYPE_ETHERNET:
 	case CONNMAN_SERVICE_TYPE_BLUETOOTH:


### PR DESCRIPTION
dbus_bool_t (32bit) and bool are two different types and has different size. This prevent crash when having service files.
