### PR TITLE
[connman] vpn: Do not start connman-vpnd automatically

### DIFF
--- a/rpm/connman.spec
+++ b/rpm/connman.spec
@@ -155,7 +155,7 @@ systemctl daemon-reload || :
 /%{_lib}/systemd/system/connman.service
 /%{_lib}/systemd/system/network.target.wants/connman.service
 /%{_lib}/systemd/system/connman-vpn.service
-%{_datadir}/dbus-1/system-services/net.connman.vpn.service
+%exclude %{_datadir}/dbus-1/system-services/net.connman.vpn.service
 
 %files devel
 %defattr(-,root,root,-)


### PR DESCRIPTION
To save memory for most users, disable connman-vpnd start at bootup by
systemd and also disable D-Bus activation (as connmand vpn plugin will
issue a net.connman.vpn call at startup)

The daemon can still be started and stopped with systemctl after the
changes.
