### PR TITLE
ofono: Submit the next SetProperty("Active") in any case

### DIFF
--- a/connman/plugins/ofono.c
+++ b/connman/plugins/ofono.c
@@ -550,11 +550,12 @@ static void context_set_active_reply(struct modem_data *modem,
 {
 	DBG("%s", modem->path);
 
+	context_submit_next_active_request(modem);
+
 	if (success) {
 		/*
 		 * oFono will send the change via PropertyChanged singal.
 		 */
-		context_submit_next_active_request(modem);
 		return;
 	}
 


### PR DESCRIPTION
Even if the previous one failed. It's hard to imagine any harm out of it while positive recovery scenarios are conceivable.
