### PR TITLE
[connman] Cancel browser requests if useragent has not returned anything

### DIFF
--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -724,6 +724,8 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 		break;
 	case 204:
 		portal_manage_status(result, wp_context);
+		// Cancel browser requests if useragent has not returned anything
+		connman_agent_cancel(wp_context->service);
 		return false;
 	case 302:
 	DBG("tls %d, Location header %d",(!g_web_supports_tls() ), (!g_web_result_get_header(result, "Location",


### PR DESCRIPTION
When succesfully in online-state, we do not need to wait for the useragent
to return anything.
