### PR TITLE
[connman] network: protect service structure access with reference

### DIFF
--- a/connman/src/network.c
+++ b/connman/src/network.c
@@ -702,6 +702,8 @@ static void set_disconnected(struct connman_network *network)
 	struct connman_service *service;
 
 	service = connman_service_lookup_from_network(network);
+	if (service)
+		connman_service_ref(service);
 
 	ipconfig_ipv4 = __connman_service_get_ip4config(service);
 	ipconfig_ipv6 = __connman_service_get_ip6config(service);
@@ -800,6 +802,9 @@ static void set_disconnected(struct connman_network *network)
 	network->connected = false;
 
 	connman_network_set_associating(network, false);
+
+	if (service)
+		connman_service_unref(service);
 }
 
 


### PR DESCRIPTION
As __connman_connection_gateway_remove() may unref service, wrap
network.c:set_disconnected() with connman_service_ref/unref to make
sure the struct stays around during the function call.
