### PR TITLE
Cleanup reachables on exit

### DIFF
--- a/connman/gsupplicant/dbus.c
+++ b/connman/gsupplicant/dbus.c
@@ -497,22 +497,31 @@ int supplicant_dbus_method_call(const char *path,
 	if (!path || !interface || !method)
 		return -EINVAL;
 
-	method_call = g_try_new0(struct method_call_data, 1);
-	if (!method_call)
-		return -ENOMEM;
-
 	message = dbus_message_new_method_call(SUPPLICANT_SERVICE, path,
 							interface, method);
-	if (!message) {
-		g_free(method_call);
+	if (!message)
 		return -ENOMEM;
-	}
 
 	dbus_message_set_auto_start(message, FALSE);
 
 	dbus_message_iter_init_append(message, &iter);
 	if (setup)
 		setup(&iter, user_data);
+
+	/* No need to wait for reply if there's no reply function */
+	if (!function) {
+		int r = dbus_connection_send(connection, message, NULL)
+			? 0
+			: -EIO;
+		dbus_message_unref(message);
+		return r;
+	}
+
+	method_call = g_try_new0(struct method_call_data, 1);
+	if (!method_call) {
+		dbus_message_unref(message);
+		return -ENOMEM;
+	}
 
 	if (!dbus_connection_send_with_reply(connection, message,
 						&call, TIMEOUT)) {

--- a/connman/plugins/bluetooth.c
+++ b/connman/plugins/bluetooth.c
@@ -957,6 +957,8 @@ static void bluetooth_exit(void)
 	 */
 	device_driver.disable = NULL;
 
+	g_dbus_client_unref(client);
+
 	connman_network_driver_unregister(&network_driver);
 	g_hash_table_destroy(networks);
 

--- a/connman/plugins/jolla-gps.c
+++ b/connman/plugins/jolla-gps.c
@@ -308,6 +308,10 @@ static void jolla_gps_exit()
 
     connman_device_driver_unregister(&device_driver);
     connman_technology_driver_unregister(&tech_driver);
+
+    g_dbus_remove_watch(connection, device_watch);
+    g_dbus_remove_watch(connection, watch);
+    dbus_connection_unref(connection);
 }
 
 CONNMAN_PLUGIN_DEFINE(jolla_gps, "Jolla GPS", VERSION, CONNMAN_PLUGIN_PRIORITY_DEFAULT,

--- a/connman/src/dnsproxy.c
+++ b/connman/src/dnsproxy.c
@@ -215,6 +215,7 @@ static GSList *request_list = NULL;
 static GHashTable *listener_table = NULL;
 static time_t next_refresh;
 static GHashTable *partial_tcp_req_table;
+static guint cache_timer = 0;
 
 static guint16 get_id(void)
 {
@@ -763,6 +764,8 @@ static void cache_element_destroy(gpointer value)
 
 static gboolean try_remove_cache(gpointer user_data)
 {
+	cache_timer = 0;
+
 	if (__sync_fetch_and_sub(&cache_refcount, 1) == 1) {
 		DBG("No cache users, removing it.");
 
@@ -2205,8 +2208,8 @@ static void destroy_server(struct server_data *server)
 	 * without any good reason. The small delay allows the new RDNSS to
 	 * create a new DNS server instance and the refcount does not go to 0.
 	 */
-	if (cache)
-		g_timeout_add_seconds(3, try_remove_cache, NULL);
+	if (cache && !cache_timer)
+		cache_timer = g_timeout_add_seconds(3, try_remove_cache, NULL);
 
 	g_free(server);
 }
@@ -3862,6 +3865,14 @@ destroy:
 void __connman_dnsproxy_cleanup(void)
 {
 	DBG("");
+
+	if (cache_timer) {
+		g_source_remove(cache_timer);
+		cache_timer = 0;
+	}
+
+	g_hash_table_destroy(cache);
+	cache = NULL;
 
 	connman_notifier_unregister(&dnsproxy_notifier);
 

--- a/connman/src/main.c
+++ b/connman/src/main.c
@@ -796,6 +796,7 @@ int main(int argc, char *argv[])
 	g_strfreev(connman_settings.tethering_technologies);
 
 	g_free(option_debug);
+	g_free(option_wifi);
 
 	return 0;
 }

--- a/connman/src/peer.c
+++ b/connman/src/peer.c
@@ -312,6 +312,10 @@ void __connman_peer_cleanup(void)
 {
 	DBG("");
 
+	g_hash_table_destroy(peers_notify->remove);
+	g_hash_table_destroy(peers_notify->add);
+	g_free(peers_notify);
+
 	g_hash_table_destroy(peers_table);
 	dbus_connection_unref(connection);
 }

--- a/connman/src/rtnl.c
+++ b/connman/src/rtnl.c
@@ -1297,6 +1297,7 @@ static const char *type2string(uint16_t type)
 }
 
 static GIOChannel *channel = NULL;
+static guint channel_watch = 0;
 
 struct rtnl_request {
 	struct nlmsghdr hdr;
@@ -1627,8 +1628,9 @@ int __connman_rtnl_init(void)
 	g_io_channel_set_encoding(channel, NULL, NULL);
 	g_io_channel_set_buffered(channel, FALSE);
 
-	g_io_add_watch(channel, G_IO_IN | G_IO_NVAL | G_IO_HUP | G_IO_ERR,
-							netlink_event, NULL);
+	channel_watch = g_io_add_watch(channel,
+				G_IO_IN | G_IO_NVAL | G_IO_HUP | G_IO_ERR,
+				netlink_event, NULL);
 
 	return 0;
 }
@@ -1677,6 +1679,11 @@ void __connman_rtnl_cleanup(void)
 
 	g_slist_free(request_list);
 	request_list = NULL;
+
+	if (channel_watch) {
+		g_source_remove(channel_watch);
+		channel_watch = 0;
+	}
 
 	g_io_channel_shutdown(channel, TRUE, NULL);
 	g_io_channel_unref(channel);

--- a/connman/src/technology.c
+++ b/connman/src/technology.c
@@ -1798,6 +1798,12 @@ void __connman_technology_cleanup(void)
 {
 	DBG("");
 
+	while (technology_list) {
+		struct connman_technology *technology = technology_list->data;
+		technology_list = g_slist_remove(technology_list, technology);
+		technology_put(technology);
+	}
+
 	g_hash_table_destroy(rfkill_list);
 
 	dbus_connection_unref(connection);


### PR DESCRIPTION
Unfreed (but still reachable) memory is cluttering valgrind report quite a bit; some of it isn't possible to remove without touching glib, but the changes in this PR alleviate the situation at least a bit. 

PR contains also a more general optimization for supplicant D-Bus calls: if there's not callback function to handle a reply from supplicant, don't bother requesting the reply in the method call.
