### PR TITLE
[connman] counter: fix possible memory leak

### DIFF
--- a/connman/src/counter.c
+++ b/connman/src/counter.c
@@ -134,8 +134,11 @@ void __connman_counter_send_usage(const char *path,
 	struct connman_counter *counter;
 
 	counter = g_hash_table_lookup(counter_table, path);
-	if (!counter)
+	if (!counter) {
+		if (message)
+			dbus_message_unref(message);
 		return;
+	}
 
 	dbus_message_set_destination(message, counter->owner);
 	dbus_message_set_path(message, counter->path);


### PR DESCRIPTION
DBusMessage message leaks memory if not cleaned when
counter is not found.