### PR TITLE
[connman] configurable tethering/ippool starting subnet

### DIFF
--- a/connman/src/ippool.c
+++ b/connman/src/ippool.c
@@ -60,6 +60,7 @@ struct connman_ippool {
 GSList *allocated_blocks;
 GHashTable *pool_hash;
 
+static uint32_t starting_block;
 static uint32_t block_16_bits;
 static uint32_t block_20_bits;
 static uint32_t block_24_bits;
@@ -173,12 +174,12 @@ static uint32_t get_free_block(unsigned int size)
 
 	/*
 	 * We want to try to get the same block (192.168.0.0) every
-	 * time.
+	 * time, unless starting_block is set something different.
 	 *
 	 * To only thing we have to make sure is that we terminated if
 	 * there is no block left.
 	 */
-	last_block = block = block_16_bits;
+	last_block = block = starting_block;
 
 	do {
 		collision = false;
@@ -441,6 +442,12 @@ int __connman_ippool_init(void)
 	block_20_bits = ntohl(inet_addr("172.16.0.0"));
 	block_24_bits = ntohl(inet_addr("10.0.0.0"));
 	subnet_mask_24 = ntohl(inet_addr("255.255.255.0"));
+
+	starting_block = ntohl(inet_addr(connman_option_get_string(
+						"TetheringSubnetBlock")));
+
+	if (!is_private_address(starting_block))
+		starting_block = block_16_bits;
 
 	pool_hash = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL,
 					pool_free);

--- a/connman/unit/test-ippool.c
+++ b/connman/unit/test-ippool.c
@@ -39,6 +39,11 @@
 #define LOG(fmt, arg...)
 #endif
 
+const char *connman_option_get_string(const char *key)
+{
+	return "192.168.0.0";
+}
+
 static void test_case_1(void)
 {
 	struct connman_ippool *pool;


### PR DESCRIPTION
Adds TetheringSubnetBlock as supported configuration
option. TetheringSubnetBlock = 192.168.199.0 makes
ippool to start allocating blocks from 192.168.199.0.