### PR TITLE
Supplicant dbus refix

### DIFF
--- a/connman/gsupplicant/supplicant.c
+++ b/connman/gsupplicant/supplicant.c
@@ -3054,9 +3054,12 @@ int g_supplicant_interface_remove(GSupplicantInterface *interface,
 						SUPPLICANT_INTERFACE,
 						"RemoveInterface",
 						interface_remove_params,
-						interface_remove_result, data,
+						callback
+						? interface_remove_result
+						: NULL,
+						data,
 						NULL);
-	if (ret < 0) {
+	if (ret < 0 || !callback) {
 		g_free(data->path);
 		dbus_free(data);
 	}

--- a/connman/gsupplicant/supplicant.c
+++ b/connman/gsupplicant/supplicant.c
@@ -3021,8 +3021,7 @@ static void interface_remove_params(DBusMessageIter *iter, void *user_data)
 {
 	struct interface_data *data = user_data;
 
-	if (data)
-		dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH,
+	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH,
 							&data->interface->path);
 }
 
@@ -3031,7 +3030,7 @@ int g_supplicant_interface_remove(GSupplicantInterface *interface,
 			GSupplicantInterfaceCallback callback,
 							void *user_data)
 {
-	struct interface_data *data = NULL;
+	struct interface_data *data;
 	int ret;
 
 	if (!interface)
@@ -3042,27 +3041,22 @@ int g_supplicant_interface_remove(GSupplicantInterface *interface,
 
 	g_supplicant_interface_cancel(interface);
 
-	if (callback) {
-		data = dbus_malloc0(sizeof(*data));
-		if (!data)
-			return -ENOMEM;
+	data = dbus_malloc0(sizeof(*data));
+	if (!data)
+		return -ENOMEM;
 
-		data->interface = interface;
-		data->path = g_strdup(interface->path);
-		data->callback = callback;
-		data->user_data = user_data;
-	}
+	data->interface = interface;
+	data->path = g_strdup(interface->path);
+	data->callback = callback;
+	data->user_data = user_data;
 
 	ret = supplicant_dbus_method_call(SUPPLICANT_PATH,
 						SUPPLICANT_INTERFACE,
 						"RemoveInterface",
 						interface_remove_params,
-						data
-						? interface_remove_result
-						: NULL,
-						data,
+						interface_remove_result, data,
 						NULL);
-	if (ret < 0 && data) {
+	if (ret < 0) {
 		g_free(data->path);
 		dbus_free(data);
 	}


### PR DESCRIPTION
Reverted the previous commit for avoiding interface removal reply as it had a bug: object path parameter was not added to the D-Bus message if there wasn't a callback function. New version adds the parameter always as it should be done. 