### PR TITLE
ofono: return -EINPROGRESS from connect/disconnect

### DIFF
--- a/connman/plugins/ofono.c
+++ b/connman/plugins/ofono.c
@@ -609,9 +609,6 @@ static int context_submit_next_active_request(struct modem_data *modem)
 				"Active", DBUS_TYPE_BOOLEAN,
 				&active,
 				context_set_active_reply);
-
-		if (!active && err == -EINPROGRESS)
-			err = 0;
 	}
 
 	return err;
@@ -627,7 +624,7 @@ static int context_set_active(struct modem_data *modem, gboolean active)
 					OFONO_ACTIVE_REQUEST_DEACTIVATE);
 
 	if (g_hash_table_lookup(modem->set_property_calls, "Active"))
-		return 0;
+		return -EINPROGRESS;
 
 	return context_submit_next_active_request(modem);
 }


### PR DESCRIPTION
This prevents connman from calling disconnect before connect is finished and generally calms the whole thing down.

The second wispr-related checkin is part of this pull request because for some reason fixing the ofono problem made the wispr crash occur much more often than before.