### PR TITLE
gsupplicant: Use OPEN auth_alg for open wifi networks

### DIFF
--- a/connman/gsupplicant/supplicant.c
+++ b/connman/gsupplicant/supplicant.c
@@ -3455,6 +3455,14 @@ error:
 	g_free(data);
 }
 
+static void add_network_security_none(DBusMessageIter *dict)
+{
+	const char *auth_alg = "OPEN";
+
+	supplicant_dbus_dict_append_basic(dict, "auth_alg",
+					DBUS_TYPE_STRING, &auth_alg);
+}
+
 static void add_network_security_wep(DBusMessageIter *dict,
 					GSupplicantSSID *ssid)
 {
@@ -3800,8 +3808,12 @@ static void add_network_security(DBusMessageIter *dict, GSupplicantSSID *ssid)
 	char *key_mgmt;
 
 	switch (ssid->security) {
-	case G_SUPPLICANT_SECURITY_UNKNOWN:
 	case G_SUPPLICANT_SECURITY_NONE:
+		key_mgmt = "NONE";
+		add_network_security_none(dict);
+		add_network_security_ciphers(dict, ssid);
+		break;
+	case G_SUPPLICANT_SECURITY_UNKNOWN:
 	case G_SUPPLICANT_SECURITY_WEP:
 		key_mgmt = "NONE";
 		add_network_security_wep(dict, ssid);


### PR DESCRIPTION
With auth_alg set to "OPEN SHARED" some drivers (particularly bcmdhd on nexus) won't connect to open wifi access points.