### PR TITLE
[connman] ipconfig: Use only settings related to configuration method

### DIFF
--- a/connman/src/ipconfig.c
+++ b/connman/src/ipconfig.c
@@ -2274,42 +2274,59 @@ int __connman_ipconfig_load(struct connman_ipconfig *ipconfig,
 	g_free(method);
 	g_free(key);
 
-	key = g_strdup_printf("%snetmask_prefixlen", prefix);
-	ipconfig->address->prefixlen = g_key_file_get_integer(
-				keyfile, identifier, key, NULL);
-	g_free(key);
+	switch (ipconfig->method) {
+	case CONNMAN_IPCONFIG_METHOD_UNKNOWN:
+	case CONNMAN_IPCONFIG_METHOD_OFF:
+		break;
 
-	key = g_strdup_printf("%slocal_address", prefix);
-	g_free(ipconfig->address->local);
-	ipconfig->address->local = g_key_file_get_string(
+	case CONNMAN_IPCONFIG_METHOD_FIXED:
+	case CONNMAN_IPCONFIG_METHOD_MANUAL:
+
+		key = g_strdup_printf("%snetmask_prefixlen", prefix);
+		ipconfig->address->prefixlen = g_key_file_get_integer(
+				keyfile, identifier, key, NULL);
+		g_free(key);
+
+		key = g_strdup_printf("%slocal_address", prefix);
+		g_free(ipconfig->address->local);
+		ipconfig->address->local = g_key_file_get_string(
 			keyfile, identifier, key, NULL);
-	g_free(key);
+		g_free(key);
 
-	key = g_strdup_printf("%speer_address", prefix);
-	g_free(ipconfig->address->peer);
-	ipconfig->address->peer = g_key_file_get_string(
+		key = g_strdup_printf("%speer_address", prefix);
+		g_free(ipconfig->address->peer);
+		ipconfig->address->peer = g_key_file_get_string(
 				keyfile, identifier, key, NULL);
-	g_free(key);
+		g_free(key);
 
-	key = g_strdup_printf("%sbroadcast_address", prefix);
-	g_free(ipconfig->address->broadcast);
-	ipconfig->address->broadcast = g_key_file_get_string(
+		key = g_strdup_printf("%sbroadcast_address", prefix);
+		g_free(ipconfig->address->broadcast);
+		ipconfig->address->broadcast = g_key_file_get_string(
 				keyfile, identifier, key, NULL);
-	g_free(key);
+		g_free(key);
 
-	key = g_strdup_printf("%sgateway", prefix);
-	g_free(ipconfig->address->gateway);
-	ipconfig->address->gateway = g_key_file_get_string(
+		key = g_strdup_printf("%sgateway", prefix);
+		g_free(ipconfig->address->gateway);
+		ipconfig->address->gateway = g_key_file_get_string(
 				keyfile, identifier, key, NULL);
-	g_free(key);
+		g_free(key);
+		break;
 
-	key = g_strdup_printf("%sDHCP.LastAddress", prefix);
-	str = g_key_file_get_string(keyfile, identifier, key, NULL);
-	if (str) {
-		g_free(ipconfig->last_dhcp_address);
-		ipconfig->last_dhcp_address = str;
+	case CONNMAN_IPCONFIG_METHOD_DHCP:
+
+		key = g_strdup_printf("%sDHCP.LastAddress", prefix);
+		str = g_key_file_get_string(keyfile, identifier, key, NULL);
+		if (str) {
+			g_free(ipconfig->last_dhcp_address);
+			ipconfig->last_dhcp_address = str;
+		}
+		g_free(key);
+
+		break;
+
+	case CONNMAN_IPCONFIG_METHOD_AUTO:
+		break;
 	}
-	g_free(key);
 
 	return 0;
 }


### PR DESCRIPTION
If service is ever being configured with manual ip-address, netmask
and gateway and later changed to dhcp, the related settings must
not be read if configuration method is not manual or fixed.
Otherwise they can possible collide with the settings got from
dhcp-server if they are exactly the same
(eg. dhcp.c: lease_available_cb()). This could lead network
interface not being configured correctly.