### PR TITLE
[connman] gdhcp: Use DHCPV6_CLIENT_PORT as source port

### DIFF
--- a/connman/gdhcp/common.c
+++ b/connman/gdhcp/common.c
@@ -446,7 +446,8 @@ int dhcpv6_send_packet(int index, struct dhcpv6_packet *dhcp_pkt, int len)
 	struct iovec v;
 	struct in6_pktinfo *pktinfo;
 	struct cmsghdr *cmsg;
-	int fd, ret;
+	int fd, ret, opt = 1;
+	struct sockaddr_in6 src;
 	struct sockaddr_in6 dst;
 	void *control_buf;
 	size_t control_buf_len;
@@ -454,6 +455,17 @@ int dhcpv6_send_packet(int index, struct dhcpv6_packet *dhcp_pkt, int len)
 	fd = socket(PF_INET6, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
 	if (fd < 0)
 		return -errno;
+
+	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+	memset(&src, 0, sizeof(src));
+	src.sin6_family = AF_INET6;
+	src.sin6_port = htons(DHCPV6_CLIENT_PORT);
+
+	if (bind(fd, (struct sockaddr *) &src, sizeof(src)) <0) {
+		close(fd);
+		return -errno;
+	}
 
 	memset(&dst, 0, sizeof(dst));
 	dst.sin6_family = AF_INET6;


### PR DESCRIPTION
Some buggy dhcpv6-server implementations are re-using
the original source port from the dhcpv6-client messages
to their dhcpv6-reply packets (eg. Cisco EPC3940L) as a
destination port. Due to this we need to make sure that we
use DHCPV6_CLIENT_PORT (udp/546) as the source port when sending
client dhcpv6-messages.