### PR TITLE
[connman] ofono: Return 0 if we are disconnecting and inprogress

### DIFF
--- a/connman/plugins/ofono.c
+++ b/connman/plugins/ofono.c
@@ -609,6 +609,9 @@ static int context_submit_next_active_request(struct modem_data *modem)
 				"Active", DBUS_TYPE_BOOLEAN,
 				&active,
 				context_set_active_reply);
+
+		if (!active && err == -EINPROGRESS)
+			return 0;
 	}
 
 	return err;


### PR DESCRIPTION
We can't return EINPROGRESS because it will cause
__connman_network_disconnect() not to call set_disconnected().

And that will cause weird problems like dhcp not stopping properly
and continuing on the next service we connect to. Eg. we will
see dhcpv6 info requests on wifi before we have seen reply to router
solicitation.