### PR TITLE
[connman] network: stop dhcpv6 also when method is _FIXED

### DIFF
--- a/connman/src/network.c
+++ b/connman/src/network.c
@@ -726,8 +726,13 @@ static void set_disconnected(struct connman_network *network)
 		switch (ipv6_method) {
 		case CONNMAN_IPCONFIG_METHOD_UNKNOWN:
 		case CONNMAN_IPCONFIG_METHOD_OFF:
-		case CONNMAN_IPCONFIG_METHOD_FIXED:
 		case CONNMAN_IPCONFIG_METHOD_MANUAL:
+			break;
+		case CONNMAN_IPCONFIG_METHOD_FIXED:
+			/* Dirty hack until we can get the cellular
+			   stack to work completly on auto-method. */
+			if (network->type == CONNMAN_NETWORK_TYPE_CELLULAR)
+				release_dhcpv6(network);
 			break;
 		case CONNMAN_IPCONFIG_METHOD_DHCP:
 		case CONNMAN_IPCONFIG_METHOD_AUTO:


### PR DESCRIPTION
This is due bug in ConnMan not handling plain ipv6-connections
correctly with ipv6-only cellular-connections. Can be reverted
when the ipv6-only works correctly with _AUTO-method with ofono.