### PR TITLE
Disconnect services when technology is disabled

### DIFF
--- a/connman/include/service.h
+++ b/connman/include/service.h
@@ -113,6 +113,7 @@ void connman_service_unref_debug(struct connman_service *service,
 			const char *file, int line, const char *caller);
 
 enum connman_service_type connman_service_get_type(struct connman_service *service);
+void connman_service_disconnect_by_type(enum connman_service_type type);
 char *connman_service_get_interface(struct connman_service *service);
 
 const char *connman_service_get_domainname(struct connman_service *service);

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -3799,6 +3799,18 @@ static bool is_ignore(struct connman_service *service)
 	return false;
 }
 
+void connman_service_disconnect_by_type(enum connman_service_type type)
+{
+	GList *list;
+
+	for (list = service_list; list; list = list->next) {
+		struct connman_service *service = list->data;
+
+		if (service->type == type)
+			__connman_service_disconnect(service);
+	}
+}
+
 static void disconnect_on_last_session(enum connman_service_type type)
 {
 	GList *list;

--- a/connman/src/technology.c
+++ b/connman/src/technology.c
@@ -790,6 +790,7 @@ static int technology_disable(struct connman_technology *technology)
 	if (technology->tethering)
 		set_tethering(technology, false);
 
+	connman_service_disconnect_by_type(technology->type);
 	err = technology_affect_devices(technology, false);
 
 	if (technology->rfkill_driven)


### PR DESCRIPTION
Otherwise wifi services periodically get stuck in the READY state and remain there forever, neither working nor allowing other wifi services to connect. This trick should allow resetting it back to a sane state by disabling/enabling technology without restarting connman.

This is more like a workaround until the root cause is fixed. But who known when the actual problem (service getting stuck) gets resolved, if ever.