### PR TITLE
[connman] service: set routes only for same family-type

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -1311,14 +1311,18 @@ static void add_nameserver_route(int family, int index, char *nameserver,
 static void nameserver_add_routes(int index, char **nameservers,
 					const char *gw)
 {
-	int i, family;
+	int i, ns_family, gw_family;
+
+	gw_family = connman_inet_check_ipaddress(gw);
+	if (gw_family < 0)
+		return;
 
 	for (i = 0; nameservers[i]; i++) {
-		family = connman_inet_check_ipaddress(nameservers[i]);
-		if (family < 0)
+		ns_family = connman_inet_check_ipaddress(nameservers[i]);
+		if (ns_family < 0 || ns_family != gw_family)
 			continue;
 
-		add_nameserver_route(family, index, nameservers[i], gw);
+		add_nameserver_route(ns_family, index, nameservers[i], gw);
 	}
 }
 


### PR DESCRIPTION
Routes should not be tried to be set with nameserver
and gw being different family, as this will lead into
having link-local routes for hosts which are not on
the link (add_nameserver_route() will add link-local route
if adding host route fails).