### PR TITLE
[connman] network: do not try to set gateway with dhcpv6

### DIFF
--- a/connman/src/network.c
+++ b/connman/src/network.c
@@ -394,10 +394,6 @@ static int dhcpv6_set_addresses(struct connman_network *network)
 	if (err < 0)
 		goto err;
 
-	err = __connman_ipconfig_gateway_add(ipconfig_ipv6);
-	if (err < 0)
-		goto err;
-
 	return 0;
 
 err:


### PR DESCRIPTION
Setting up gateway is handled by the kernel
therefore ConnMan does not need to do it
when dhcpv6 is used.

This fixes the issue with IPv6 nameserver host routes
getting added as link-local due the gateway in the
ipconfig was always null.