### PR TITLE
Fixed the check of inet_pton return value

### DIFF
--- a/connman/src/dhcpv6.c
+++ b/connman/src/dhcpv6.c
@@ -943,7 +943,7 @@ static void do_dad(GDHCPClient *dhcp_client, struct connman_dhcpv6 *dhcp)
 
 		ref_own_address(user_data);
 
-		if (inet_pton(AF_INET6, address, &addr) < 0) {
+		if (inet_pton(AF_INET6, address, &addr) < 1) {
 			DBG("Invalid IPv6 address %s %d/%s", address,
 				-errno, strerror(errno));
 			goto fail;

--- a/connman/src/inet.c
+++ b/connman/src/inet.c
@@ -647,7 +647,7 @@ int connman_inet_del_ipv6_network_route(int index, const char *host,
 
 	rt.rtmsg_dst_len = prefix_len;
 
-	if (inet_pton(AF_INET6, host, &rt.rtmsg_dst) < 0) {
+	if (inet_pton(AF_INET6, host, &rt.rtmsg_dst) < 1) {
 		err = -errno;
 		goto out;
 	}
@@ -697,17 +697,15 @@ int connman_inet_add_ipv6_network_route(int index, const char *host,
 
 	rt.rtmsg_dst_len = prefix_len;
 
-	if (inet_pton(AF_INET6, host, &rt.rtmsg_dst) < 0) {
+	if (inet_pton(AF_INET6, host, &rt.rtmsg_dst) < 1) {
 		err = -errno;
 		goto out;
 	}
 
 	rt.rtmsg_flags = RTF_UP | RTF_HOST;
 
-	if (gateway) {
+	if (gateway && inet_pton(AF_INET6, gateway, &rt.rtmsg_gateway) > 0)
 		rt.rtmsg_flags |= RTF_GATEWAY;
-		inet_pton(AF_INET6, gateway, &rt.rtmsg_gateway);
-	}
 
 	rt.rtmsg_metric = 1;
 	rt.rtmsg_ifindex = index;
@@ -749,7 +747,7 @@ int connman_inet_clear_ipv6_gateway_address(int index, const char *gateway)
 
 	memset(&rt, 0, sizeof(rt));
 
-	if (inet_pton(AF_INET6, gateway, &rt.rtmsg_gateway) < 0) {
+	if (inet_pton(AF_INET6, gateway, &rt.rtmsg_gateway) < 1) {
 		err = -errno;
 		goto out;
 	}


### PR DESCRIPTION
**inet_pton**()  returns  1  on  success (network address was successfully converted).  0 is returned if `src` does not contain a character string representing a valid network address in the specified address family.  If `af` does not contain a valid address family,  -1  is  returned  and `errno` is set to **EAFNOSUPPORT**.