### PR TITLE
Fix memory leak in check_dhcpv6

### DIFF
--- a/connman/src/network.c
+++ b/connman/src/network.c
@@ -516,8 +516,11 @@ static void check_dhcpv6(struct nd_router_advert *reply,
 	 */
 	if (reply->nd_ra_flags_reserved & ND_RA_FLAG_MANAGED)
 		__connman_dhcpv6_start(network, prefixes, dhcpv6_callback);
-	else if (reply->nd_ra_flags_reserved & ND_RA_FLAG_OTHER)
-		__connman_dhcpv6_start_info(network, dhcpv6_info_callback);
+	else {
+		g_slist_free_full(prefixes, g_free);
+		if (reply->nd_ra_flags_reserved & ND_RA_FLAG_OTHER)
+			__connman_dhcpv6_start_info(network, dhcpv6_info_callback);
+	}
 
 	connman_network_unref(network);
 }


### PR DESCRIPTION
```
==7180== 806 (208 direct, 598 indirect) bytes in 26 blocks are definitely lost in loss record 190 of 199
==7180==    at 0x483933C: malloc (vg_replace_malloc.c:296)
==7180==    by 0x48B7543: g_malloc (gmem.c:104)
==7180==    by 0x48D3E1F: g_slice_alloc (gslice.c:1016)
==7180==    by 0x48D4CDB: g_slist_prepend (gslist.c:267)
==7180==    by 0x5BF0F: __connman_inet_ipv6_get_prefixes (inet.c:2052)
==7180==    by 0x3F32B: check_dhcpv6 (network.c:499)
==7180==    by 0x58C13: icmpv6_recv (inet.c:1356)
==7180==    by 0x59357: icmpv6_event (inet.c:1372)
==7180==    by 0x59357: icmpv6_event (inet.c:1362)
==7180==    by 0x490BBB7: g_io_unix_dispatch (giounix.c:167)
==7180==    by 0x48AFB1F: g_main_dispatch (gmain.c:3066)
==7180==    by 0x48AFB1F: g_main_context_dispatch (gmain.c:3642)
==7180==    by 0x48AFE23: g_main_context_iterate.part.19 (gmain.c:3713)
==7180==    by 0x48B048B: g_main_loop_run (gmain.c:3906)
==7180==    by 0x149D3: main (main.c:761)
```