### PR TITLE
Fix crash in wispr_portal_web_result

### DIFF
--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -724,7 +724,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 			// Cancel browser requests if useragent has not returned anything
 			connman_agent_cancel(wp_context->service);
 			portal_manage_status(result, wp_context);
-			break;
+			return false;
 		} else
 			__connman_agent_request_browser(wp_context->service,
 					wispr_portal_browser_reply_cb,


### PR DESCRIPTION
wp_context is deallocated by `portal_manage_status` and can't be used after that. The problem is detected by valgrind as follows:
```
==23718== Invalid read of size 4
==23718==    at 0x735EC: wispr_portal_web_result (wispr.c:785)
==23718==    by 0x1B58B: call_result_func (gweb.c:460)
==23718==    by 0x1B58B: received_data (gweb.c:896)
==23718==    by 0x48AFB85: g_main_dispatch (gmain.c:3066)
==23718==    by 0x48AFB85: g_main_context_dispatch (gmain.c:3642)
==23718==    by 0x48AFE11: g_main_context_iterate.isra.5 (gmain.c:3713)
==23718==    by 0x48B01D3: g_main_loop_run (gmain.c:3907)
==23718==    by 0x149D3: main (main.c:761)
==23718==  Address 0x50ca0b8 is 0 bytes inside a block of size 100 free'd
==23718==    at 0x4840ABC: free (vg_replace_malloc.c:473)
==23718==    by 0x7347B: portal_manage_status (wispr.c:461)
==23718==    by 0x736FB: wispr_portal_web_result (wispr.c:726)
==23718==    by 0x1B58B: call_result_func (gweb.c:460)
==23718==    by 0x1B58B: received_data (gweb.c:896)
==23718==    by 0x48AFB85: g_main_dispatch (gmain.c:3066)
==23718==    by 0x48AFB85: g_main_context_dispatch (gmain.c:3642)
==23718==    by 0x48AFE11: g_main_context_iterate.isra.5 (gmain.c:3713)
==23718==    by 0x48B01D3: g_main_loop_run (gmain.c:3907)
==23718==    by 0x149D3: main (main.c:761)
```