### PR TITLE
Fix incorrect removal of elements from a double-linked list

### DIFF
--- a/connman/src/agent.c
+++ b/connman/src/agent.c
@@ -516,8 +516,8 @@ void connman_agent_cancel(void *user_context)
 
 				agent_request_free(request);
 
-				agent->queue = list->next;
-				list = g_list_delete_link(list, list);
+				agent->queue = g_list_delete_link(agent->queue,
+									list);
 			} else
 				list = list->next;
 		}


### PR DESCRIPTION
The way it was done, leaked all the elements from the list *before* the one being removed:
```
==15760== 4,936 (12 direct, 4,924 indirect) bytes in 1 blocks are definitely lost in loss record 232 of 234
==15760==    at 0x483933C: malloc (vg_replace_malloc.c:296)
==15760==    by 0x48B7543: g_malloc (gmem.c:104)
==15760==    by 0x48D3E1F: g_slice_alloc (gslice.c:1016)
==15760==    by 0x48AB343: g_list_append (glist.c:232)
==15760==    by 0x51567: connman_agent_queue_message (agent.c:250)
==15760==    by 0x50803: __connman_agent_request_passphrase_input (agent-connman.c:483)
==15760==    by 0x4A21F: __connman_service_connect (service.c:6463)
==15760==    by 0x4AA0B: auto_connect_service (service.c:4004)
==15760==    by 0x4AB23: run_auto_connect (service.c:4027)
==15760==    by 0x48B0BE3: g_timeout_dispatch (gmain.c:4451)
==15760==    by 0x48AFB1F: g_main_dispatch (gmain.c:3066)
==15760==    by 0x48AFB1F: g_main_context_dispatch (gmain.c:3642)
==15760==    by 0x48AFE23: g_main_context_iterate.part.19 (gmain.c:3713)
==15760==    by 0x48B048B: g_main_loop_run (gmain.c:3906)
==15760==    by 0x149D3: main (main.c:761)
```
It wasn't much of a problem though, because most of the time it was the first element that was removed.