### PR TITLE
Fix passphrase request crash

### DIFF
--- a/connman/src/agent-connman.c
+++ b/connman/src/agent-connman.c
@@ -429,6 +429,9 @@ int __connman_agent_request_passphrase_input(struct connman_service *service,
 	if (!service || !agent || !agent_path || !callback)
 		return -ESRCH;
 
+	if (!__connman_service_get_network(service))
+		return -ENOLINK;
+
 	message = dbus_message_new_method_call(agent_sender, agent_path,
 					CONNMAN_AGENT_INTERFACE,
 					"RequestInput");


### PR DESCRIPTION
Refuse to request passphrase for a service that has no network. Otherwise connman may crash like this:
```
==4805== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==4805==  Access not within mapped region at address 0x7C
==4805==    at 0x409B8: connman_network_get_string (network.c:2049)
==4805==    by 0x500D3: previous_passphrase_handler (agent-connman.c:317)
==4805==    by 0x500D3: __connman_agent_request_passphrase_input (agent-connman.c:464)
==4805==    by 0x49B77: __connman_service_connect (service.c:6463)
==4805==    by 0x4A363: auto_connect_service (service.c:4004)
==4805==    by 0x4A47B: run_auto_connect (service.c:4027)
==4805==    by 0x48B0BE3: g_timeout_dispatch (gmain.c:4451)
==4805==    by 0x48AFB1F: g_main_dispatch (gmain.c:3066)
==4805==    by 0x48AFB1F: g_main_context_dispatch (gmain.c:3642)
==4805==    by 0x48AFE23: g_main_context_iterate.part.19 (gmain.c:3713)
==4805==    by 0x48B048B: g_main_loop_run (gmain.c:3906)
==4805==    by 0x149D3: main (main.c:761)
```
This is a follow-up to https://github.com/mer-packages/connman/pull/211 which makes this situation possible (or just increases the probability of this to happen, it's hard to tell).