### PR TITLE
[connman] wifi: disconnect if 4way-handshake fails while roaming. MER#930

### DIFF
--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -1723,6 +1723,9 @@ static bool handle_4way_handshake_failure(GSupplicantInterface *interface,
 	if (wifi->state != G_SUPPLICANT_STATE_4WAY_HANDSHAKE)
 		return false;
 
+	if (wifi->connected)
+		return false;
+
 	service = connman_service_lookup_from_network(network);
 	if (!service)
 		return false;

--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -118,7 +118,6 @@ struct wifi_data {
 
 	GSupplicantScanParams *scan_params;
 	unsigned int p2p_find_timeout;
-	unsigned int carrier_timeout;
 };
 
 struct wifi_tethering_info {
@@ -133,8 +132,6 @@ static GSList *tethering_info_list = NULL;
 static GList *iface_list = NULL;
 
 static void start_autoscan(struct connman_device *device);
-static int network_disconnect(struct connman_network *network);
-static gboolean carrier_timeout(gpointer data);
 
 static int p2p_tech_probe(struct connman_technology *technology)
 {
@@ -196,14 +193,8 @@ static void wifi_newlink(unsigned flags, unsigned change, void *user_data)
 			DBG("carrier on");
 
 			handle_tethering(wifi);
-		} else {
+		} else
 			DBG("carrier off");
-			if (wifi->carrier_timeout) {
-				g_source_remove(wifi->carrier_timeout);
-			}
-			wifi->carrier_timeout = g_timeout_add_seconds(10,
-							carrier_timeout, wifi);
-		}
 	}
 
 	wifi->flags = flags;
@@ -322,10 +313,6 @@ static void wifi_remove(struct connman_device *device)
 	if (wifi->p2p_find_timeout) {
 		g_source_remove(wifi->p2p_find_timeout);
 		connman_device_unref(wifi->device);
-	}
-
-	if (wifi->carrier_timeout) {
-		g_source_remove(wifi->carrier_timeout);
 	}
 
 	if (wifi->pending_network)
@@ -782,24 +769,6 @@ out:
 	scan_callback(result, interface, user_data);
 }
 
-static gboolean carrier_timeout(gpointer data)
-{
-	struct wifi_data *wifi = data;
-
-	if (!wifi)
-		return FALSE;
-
-	wifi->carrier_timeout = 0;
-
-	if (wifi->network) {
-		connman_warn("Disconnecting due connection might be stuck...");
-		network_disconnect(wifi->network);
-
-	}
-
-	return FALSE;
-}
-
 static gboolean autoscan_timeout(gpointer data)
 {
 	struct connman_device *device = data;
@@ -992,11 +961,6 @@ static int wifi_disable(struct connman_device *device)
 		g_source_remove(wifi->p2p_find_timeout);
 		wifi->p2p_find_timeout = 0;
 		connman_device_unref(wifi->device);
-	}
-
-	if (wifi->carrier_timeout) {
-		g_source_remove(wifi->carrier_timeout);
-		wifi->carrier_timeout = 0;
 	}
 
 	/* In case of a user scan, device is still referenced */
@@ -1822,11 +1786,6 @@ static void interface_state(GSupplicantInterface *interface)
 		/* though it should be already stopped: */
 		stop_autoscan(device);
 
-		if (wifi->carrier_timeout) {
-			g_source_remove(wifi->carrier_timeout);
-			wifi->carrier_timeout = 0;
-		}
-
 		if (!handle_wps_completion(interface, network, device, wifi))
 			break;
 
@@ -1861,11 +1820,6 @@ static void interface_state(GSupplicantInterface *interface)
 		if (g_supplicant_interface_enable_selected_network(interface,
 						FALSE) != 0)
 			DBG("Could not disables selected network");
-
-		if (wifi->carrier_timeout) {
-			g_source_remove(wifi->carrier_timeout);
-			wifi->carrier_timeout = 0;
-		}
 
 		connman_network_set_connected(network, false);
 		connman_network_set_associating(network, false);


### PR DESCRIPTION
While wifi->state is G_SUPPLICANT_STATE_COMPLETED and gets changed into
G_SUPPLICANT_STATE_4WAY_HANDSHAKE the connection is most probably roaming.

However if for some reason the wifi->state changes into
G_SUPPLICANT_STATE_DISCONNECTED after being G_SUPPLICANT_STATE_4WAY_HANDSHAKE
the handle_4way_handshake_failure() is called from interface_state() it is
required to check wifi->connected and force disconnect if true.

If not the actual disconnection will be skipped unless
retries > FAVORITE_MAXIMUM_RETRIES and wifi->connected will be set as false.
Later on this will cause state-machine deadlock between network.c and wifi.c
as network.c will still think that the network is connected and after wifi.c
thinks it's not.

In short: wifi->state will change into G_SUPPLICANT_STATE_SCANNING->
G_SUPPLICANT_STATE_ASSOCIATING and connman_network_set_associating(network, true);
gets called. Now the network.c is in both associating and connected. Finally when
wifi->state goes through  G_SUPPLICANT_STATE_4WAY_HANDSHAKE ->
G_SUPPLICANT_STATE_COMPLETED the connman_network_set_connected(network, true);
will be called but it will never call set_connected as it's already connected and
service state will stay as "associating" until disconnected.
