### PR TITLE
Fix crash in modem_update_interfaces

### DIFF
--- a/connman/plugins/ofono.c
+++ b/connman/plugins/ofono.c
@@ -2143,8 +2143,18 @@ static void modem_update_interfaces(struct modem_data *modem,
 	if (api_added(old_ifaces, new_ifaces, OFONO_API_CDMA_NETREG))
 		cdma_netreg_get_properties(modem);
 
-	if (api_removed(old_ifaces, new_ifaces, OFONO_API_CM))
-		remove_cm_context(modem, modem->context->path);
+	if (api_removed(old_ifaces, new_ifaces, OFONO_API_CM)) {
+		if (modem->call_get_contexts) {
+			DBG("cancelling pending GetContexts call");
+			dbus_pending_call_cancel(modem->call_get_contexts);
+			dbus_pending_call_unref(modem->call_get_contexts);
+			modem->call_get_contexts = NULL;
+		}
+		if (modem->context) {
+			DBG("removing context %s", modem->context->path);
+			remove_cm_context(modem, modem->context->path);
+		}
+	}
 
 	if (api_removed(old_ifaces, new_ifaces, OFONO_API_CDMA_CM))
 		remove_cm_context(modem, modem->context->path);


### PR DESCRIPTION
`modem_update_interfaces()` would crash if `"org.ofono.ConnectionManager"` interface is removed right after it has been added, before `GetContext` call completes (or if it fails):

```
connmand[5141]: plugins/ofono.c:modem_changed() /ril_0 Interfaces 0x05
connmand[5141]: plugins/ofono.c:modem_update_interfaces() /ril_0
connmand[5141]: plugins/ofono.c:api_added() cm added
connmand[5141]: plugins/ofono.c:get_properties() /ril_0 path /ril_0 org.ofono.ConnectionManager
connmand[5141]: plugins/ofono.c:cm_get_contexts() /ril_0
connmand[5141]: plugins/ofono.c:cm_update_attached() /ril_0 Attached 1
connmand[5141]: plugins/ofono.c:modem_changed() /ril_0 Interfaces 0x01
connmand[5141]: plugins/ofono.c:modem_update_interfaces() /ril_0
connmand[5141]: plugins/ofono.c:api_removed() cm removed
==5141== Invalid read of size 4
==5141==    at 0x31FB4: modem_update_interfaces (ofono.c:2147)
==5141==    by 0x326F3: modem_changed (ofono.c:2214)
==5141==    by 0x82C0B: signal_filter (watch.c:407)
==5141==    by 0x82A4F: message_filter (watch.c:557)
==5141==    by 0x497AF4F: dbus_connection_dispatch (in /usr/lib/libdbus-1.so.3.7.12)
==5141==    by 0x8197F: message_dispatch (mainloop.c:72)
==5141==    by 0x48ABA8B: g_idle_dispatch (gmain.c:5251)
==5141==    by 0x48AFB1F: g_main_dispatch (gmain.c:3066)
==5141==    by 0x48AFB1F: g_main_context_dispatch (gmain.c:3642)
==5141==    by 0x48AFE23: g_main_context_iterate.part.19 (gmain.c:3713)
==5141==    by 0x48B048B: g_main_loop_run (gmain.c:3906)
==5141==    by 0x149D3: main (main.c:779)
==5141==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==5141== 
==5141== 
==5141== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==5141==  Access not within mapped region at address 0x0
==5141==    at 0x31FB4: modem_update_interfaces (ofono.c:2147)
==5141==    by 0x326F3: modem_changed (ofono.c:2214)
==5141==    by 0x82C0B: signal_filter (watch.c:407)
==5141==    by 0x82A4F: message_filter (watch.c:557)
==5141==    by 0x497AF4F: dbus_connection_dispatch (in /usr/lib/libdbus-1.so.3.7.12)
==5141==    by 0x8197F: message_dispatch (mainloop.c:72)
==5141==    by 0x48ABA8B: g_idle_dispatch (gmain.c:5251)
==5141==    by 0x48AFB1F: g_main_dispatch (gmain.c:3066)
==5141==    by 0x48AFB1F: g_main_context_dispatch (gmain.c:3642)
==5141==    by 0x48AFE23: g_main_context_iterate.part.19 (gmain.c:3713)
==5141==    by 0x48B048B: g_main_loop_run (gmain.c:3906)
==5141==    by 0x149D3: main (main.c:779)
```