### PR TITLE
Cancel pending activation when context is removed.

### DIFF
--- a/connman/plugins/ofono.c
+++ b/connman/plugins/ofono.c
@@ -1211,11 +1211,20 @@ static int add_cm_context(struct modem_data *modem, const char *context_path,
 static void remove_cm_context(struct modem_data *modem,
 				const char *context_path)
 {
+	DBusPendingCall* call;
+
 	if (!modem->context)
 		return;
 
 	if (modem->network)
 		remove_network(modem);
+
+	call = g_hash_table_lookup(modem->set_property_calls, "Active");
+	if (call) {
+		DBG("cancelling %s activation", context_path);
+		dbus_pending_call_cancel(call);
+		g_hash_table_remove(modem->set_property_calls, "Active");
+	}
 
 	g_hash_table_remove(context_hash, context_path);
 


### PR DESCRIPTION
Otherwise connman would crash if `"org.ofono.ConnectionManager"` interface is removed while SetProperty("Active") call is pending for the connection context. First, it results in access to freed memory:
```
==2144== Invalid read of size 1
==2144==    at 0x483A114: strlen (vg_replace_strmem.c:412)
==2144==    by 0x4B0609B: vfprintf (vfprintf.c:1630)
==2144==    by 0x4BB1B6B: __vfprintf_chk (vfprintf_chk.c:35)
==2144==    by 0x4B974FB: __vsyslog_chk (syslog.c:224)
==2144==    by 0x3B42B: vsyslog (syslog.h:47)
==2144==    by 0x3B42B: connman_debug (log.c:107)
==2144==    by 0x2E49F: set_property_reply (ofono.c:382)
==2144==    by 0x498B7C7: ??? (in /usr/lib/libdbus-1.so.3.7.12)
==2144==    by 0x49775FF: ??? (in /usr/lib/libdbus-1.so.3.7.12)
==2144==    by 0x497ACAB: dbus_connection_dispatch (in /usr/lib/libdbus-1.so.3.7.12)
==2144==    by 0x819F7: message_dispatch (mainloop.c:72)
==2144==    by 0x48ABA8B: g_idle_dispatch (gmain.c:5251)
==2144==    by 0x48AFB1F: g_main_dispatch (gmain.c:3066)
==2144==    by 0x48AFB1F: g_main_context_dispatch (gmain.c:3642)
==2144==    by 0x48AFE23: g_main_context_iterate.part.19 (gmain.c:3713)
==2144==    by 0x48B048B: g_main_loop_run (gmain.c:3906)
==2144==    by 0x149D3: main (main.c:779)
==2144==  Address 0x5ba5758 is 0 bytes inside a block of size 16 free'd
==2144==    at 0x4837D18: free (vg_replace_malloc.c:473)
==2144==    by 0x48B76AB: g_free (gmem.c:197)
==2144==    by 0x2F997: network_context_free (ofono.c:253)
==2144==    by 0x2FA03: remove_cm_context (ofono.c:1222)
==2144==    by 0x31F8F: modem_update_interfaces (ofono.c:2155)
==2144==    by 0x3276B: modem_changed (ofono.c:2224)
==2144==    by 0x82C83: signal_filter (watch.c:407)
==2144==    by 0x82AC7: message_filter (watch.c:557)
==2144==    by 0x497AF4F: dbus_connection_dispatch (in /usr/lib/libdbus-1.so.3.7.12)
==2144==    by 0x819F7: message_dispatch (mainloop.c:72)
==2144==    by 0x48ABA8B: g_idle_dispatch (gmain.c:5251)
==2144==    by 0x48AFB1F: g_main_dispatch (gmain.c:3066)
==2144==    by 0x48AFB1F: g_main_context_dispatch (gmain.c:3642)
==2144==    by 0x48AFE23: g_main_context_iterate.part.19 (gmain.c:3713)
==2144==    by 0x48B048B: g_main_loop_run (gmain.c:3906)
==2144==    by 0x149D3: main (main.c:779)
```
which is then followed by a crash:
```
==2144== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==2144==  Access not within mapped region at address 0x8
==2144==    at 0x32AA4: context_submit_next_active_request (ofono.c:601)
==2144==    by 0x32D0F: context_set_active_reply (ofono.c:567)
==2144==    by 0x2E46B: set_property_reply (ofono.c:400)
==2144==    by 0x498B7C7: ??? (in /usr/lib/libdbus-1.so.3.7.12)
==2144==    by 0x49775FF: ??? (in /usr/lib/libdbus-1.so.3.7.12)
==2144==    by 0x497ACAB: dbus_connection_dispatch (in /usr/lib/libdbus-1.so.3.7.12)
==2144==    by 0x819F7: message_dispatch (mainloop.c:72)
==2144==    by 0x48ABA8B: g_idle_dispatch (gmain.c:5251)
==2144==    by 0x48AFB1F: g_main_dispatch (gmain.c:3066)
==2144==    by 0x48AFB1F: g_main_context_dispatch (gmain.c:3642)
==2144==    by 0x48AFE23: g_main_context_iterate.part.19 (gmain.c:3713)
==2144==    by 0x48B048B: g_main_loop_run (gmain.c:3906)
==2144==    by 0x149D3: main (main.c:779)
```