### PR TITLE
[connman] revert disabling scanning while associating. MER#955

### DIFF
--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -630,12 +630,12 @@ static int throw_wifi_scan(struct connman_device *device,
 		return -ENODEV;
 
 	struct connman_network *network = wifi->network;
-	if (network && connman_network_get_associating(network)) {
-		return -EBUSY;
-	}
+	if (!network)
+		return -ENODEV;
+
 	DBG("device %p %p", device, wifi->interface);
 
-	if (wifi->tethering)
+	if (wifi->tethering || connman_network_get_associating(network))
 		return -EBUSY;
 
 	if (connman_device_get_scanning(device))

--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -629,13 +629,9 @@ static int throw_wifi_scan(struct connman_device *device,
 	if (!wifi)
 		return -ENODEV;
 
-	struct connman_network *network = wifi->network;
-	if (!network)
-		return -ENODEV;
-
 	DBG("device %p %p", device, wifi->interface);
 
-	if (wifi->tethering || connman_network_get_associating(network))
+	if (wifi->tethering)
 		return -EBUSY;
 
 	if (connman_device_get_scanning(device))


### PR DESCRIPTION
This does not make any sense and does not exists in the upstream either.