### PR TITLE
[connman] wifi: disconnect if wpa_s state changes from completed to scanning. MER#930

### DIFF
--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -1774,6 +1774,9 @@ static void interface_state(GSupplicantInterface *interface)
 
 	switch (state) {
 	case G_SUPPLICANT_STATE_SCANNING:
+		if (wifi->connected)
+			connman_network_set_connected(network, false);
+
 		break;
 
 	case G_SUPPLICANT_STATE_AUTHENTICATING:
@@ -1866,6 +1869,13 @@ static void interface_state(GSupplicantInterface *interface)
 			connman_warn("Probably roaming right now!"
 						" Staying connected...");
 		else
+			wifi->connected = false;
+		break;
+	case G_SUPPLICANT_STATE_SCANNING:
+		if (wifi->connected) {
+			wifi->connected = false;
+			start_autoscan(device);
+		} else
 			wifi->connected = false;
 		break;
 	case G_SUPPLICANT_STATE_COMPLETED:


### PR DESCRIPTION
It's possible from wpa_s to change the state from completed to scanning
without going through disconnected state if interface signals that the carrier
went off and on (IFF_LOWER_UP flag).

This will cause dead lock similar in e770b6e05f48922ef76b5b150de26c26949910ae
if the wifi gets into associating state as the network->connected is still true
but wifi->connected is not.