### PR TITLE
Drop references to dead networks

### DIFF
--- a/connman/src/agent-connman.c
+++ b/connman/src/agent-connman.c
@@ -429,6 +429,9 @@ int __connman_agent_request_passphrase_input(struct connman_service *service,
 	if (!service || !agent || !agent_path || !callback)
 		return -ESRCH;
 
+	if (!__connman_service_get_network(service))
+		return -ENOLINK;
+
 	message = dbus_message_new_method_call(agent_sender, agent_path,
 					CONNMAN_AGENT_INTERFACE,
 					"RequestInput");

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -7065,6 +7065,11 @@ static void update_from_network(struct connman_service *service,
 	if (is_connected(service))
 		return;
 
+	if (service->network && service->network != network) {
+		connman_network_unref(service->network);
+		service->network = NULL;
+	}
+
 	if (is_connecting(service))
 		return;
 
@@ -7281,6 +7286,11 @@ void __connman_service_remove_from_network(struct connman_network *network)
 					CONNMAN_IPCONFIG_TYPE_ALL);
 
 	stop_recurring_online_check(service);
+
+	if (service->network) {
+		connman_network_unref(service->network);
+		service->network = NULL;
+	}
 
 	connman_service_unref(service);
 }


### PR DESCRIPTION
This is essentially two old pull requests https://github.com/mer-packages/connman/pull/211 and https://github.com/mer-packages/connman/pull/212 rolled into one. I just had the exact same problem that I though was fixed (`network->connecting` and `network->associating` are true, `network->driver` is NULL, nothing works) with very recent connman 1.24+git98. So it appears that the problem hasn't been completely fixed by any of the recent changes.

The problem reproduced itself after a sudden reboot of the access point (due to a power surge).

And yes, this PR doesn't really fix anything, it's about recovering from the above described condition. These changes haven't been accepted by upstream because *"no recovery is necessary if everything works as it's supposed to"* or something along those lines. I'm fine with removing these changes in the wonderful future where everything is working the way it's supposed to. Until then, let's have some sort of recovery mechanism in place.