### PR TITLE
Reset state to idle when disassociating service from network

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -7282,6 +7282,12 @@ void __connman_service_remove_from_network(struct connman_network *network)
 
 	stop_recurring_online_check(service);
 
+	__connman_service_ipconfig_indicate_state(service,
+						CONNMAN_SERVICE_STATE_IDLE,
+						CONNMAN_IPCONFIG_TYPE_IPV4);
+	__connman_service_ipconfig_indicate_state(service,
+						CONNMAN_SERVICE_STATE_IDLE,
+						CONNMAN_IPCONFIG_TYPE_IPV6);
 	connman_service_unref(service);
 }
 


### PR DESCRIPTION
Otherwise, service may stay in the `ASSOCIATION` state forever and `update_from_network()` won't do anything because `is_connecting()` keeps returning true, making recovery impossible.

These hickups are pretty hard to catch but they do happen quite often (once in a few days) in the areas with unstable wifi reception.