### PR TITLE
Make signal strength polling less destructive

### DIFF
--- a/connman/include/service.h
+++ b/connman/include/service.h
@@ -129,6 +129,7 @@ bool connman_service_get_favorite(struct connman_service *service);
 bool connman_service_get_autoconnect(struct connman_service *service);
 
 struct connman_service *connman_service_lookup_from_network(struct connman_network *network);
+void connman_service_update_strength_from_network(struct connman_network *network);
 
 void connman_service_create_ip4config(struct connman_service *service,
 								int index);

--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -1405,7 +1405,7 @@ static void wifi_update_strength(struct wifi_data *wifi, unsigned char strength)
 
 		DBG("average %u", sum/n);
 		connman_network_set_strength(wifi->network, sum/n);
-		connman_network_update(wifi->network);
+		connman_service_update_strength_from_network(wifi->network);
 	}
 }
 

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -7264,6 +7264,22 @@ sorting:
 	}
 }
 
+void connman_service_update_strength_from_network(struct connman_network *network)
+{
+	struct connman_service *service;
+
+	service = connman_service_lookup_from_network(network);
+	if (service && service->network) {
+		uint8_t strength;
+
+		strength = connman_network_get_strength(service->network);
+		if (service->strength != strength) {
+			service->strength = strength;
+			strength_changed(service);
+		}
+	}
+}
+
 void __connman_service_remove_from_network(struct connman_network *network)
 {
 	struct connman_service *service;


### PR DESCRIPTION
When signal strength changes as a result of a poll, just update the service strength property and don't do anything else (like re-sorting the services which may have various side-effects)