### PR TITLE
signalpoll: Prevent service link from being freed twice

### DIFF
--- a/connman/plugins/jolla-signalpoll.c
+++ b/connman/plugins/jolla-signalpoll.c
@@ -135,8 +135,8 @@ static void signalpoll_remove_poll_service(struct connman_service *service)
 	DBG("%s (%sfound)", __connman_service_get_ident(service),
 							found ? "" : "not ");
 	if (found) {
-		connman_service_unref(service);
 		poll_services = g_slist_delete_link(poll_services, found);
+		connman_service_unref(service);
 		if (!poll_services) {
 			signalpoll_update();
 		}


### PR DESCRIPTION
Dereferencing the service may result in `signalpoll_remove_poll_service()` being called again on the same stack like this:

```
==4093== Invalid write of size 4
==4093==    at 0x40301A0: memset (mc_replace_strmem.c:1007)
==4093==    by 0x40C7414: g_slice_free1 (string3.h:84)
==4093==    by 0x40C7F94: g_slist_delete_link (gslist.c:557)
==4093==    by 0x808061C: signalpoll_remove_poll_service (jolla-signalpoll.c:139)
==4093==    by 0x80806A9: signalpoll_service_state_changed (jolla-signalpoll.c:154)
==4093==    by 0x80A5A16: __connman_notifier_service_state_changed (notifier.c:324)
==4093==    by 0x8095B98: state_changed (service.c:1510)
==4093==    by 0x809DBD3: service_indicate_state (service.c:5735)
==4093==    by 0x809E8A3: __connman_service_ipconfig_indicate_state (service.c:6224)
==4093==    by 0x809B2F0: connect_timeout (service.c:4278)
==4093==    by 0x409E366: g_timeout_dispatch (gmain.c:4451)
==4093==    by 0x409D527: g_main_context_dispatch (gmain.c:3066)
==4093==  Address 0x57d7e98 is 0 bytes inside a block of size 8 free'd
==4093==    at 0x402C109: free (vg_replace_malloc.c:446)
==4093==    by 0x40A5641: g_free (gmem.c:197)
==4093==    by 0x40C741F: g_slice_free1 (gslice.c:1124)
==4093==    by 0x40C7F94: g_slist_delete_link (gslist.c:557)
==4093==    by 0x808061C: signalpoll_remove_poll_service (jolla-signalpoll.c:139)
==4093==    by 0x80A5825: __connman_notifier_service_remove (notifier.c:257)
==4093==    by 0x809C6EB: service_free (service.c:4917)
==4093==    by 0x40853B1: g_hash_table_remove (ghash.c:448)
==4093==    by 0x809CA4F: connman_service_unref_debug (service.c:5051)
==4093==    by 0x8080608: signalpoll_remove_poll_service (jolla-signalpoll.c:138)
==4093==    by 0x80806A9: signalpoll_service_state_changed (jolla-signalpoll.c:154)
==4093==    by 0x80A5A16: __connman_notifier_service_state_changed (notifier.c:324)
```
That explains the slice allocator crashes we have been seeing recently.