### PR TITLE
Don't assume that default gateway acts as NTP server

### DIFF
--- a/connman/src/timeserver.c
+++ b/connman/src/timeserver.c
@@ -179,13 +179,17 @@ GSList *__connman_timeserver_add_list(GSList *server_list,
 GSList *__connman_timeserver_get_all(struct connman_service *service)
 {
 	GSList *list = NULL;
-	struct connman_network *network;
 	char **timeservers;
 	char **service_ts;
 	char **service_ts_config;
-	const char *service_gw;
 	char **fallback_ts;
-	int index, i;
+	int i;
+
+#ifdef DEFAULT_GW_SUPPORTS_NTP
+	struct connman_network *network;
+	const char *service_gw;
+	int index;
+#endif
 
 	if (__connman_clock_timeupdates() == TIME_UPDATES_MANUAL)
 		return NULL;
@@ -204,6 +208,7 @@ GSList *__connman_timeserver_get_all(struct connman_service *service)
 	for (i = 0; service_ts && service_ts[i]; i++)
 		list = __connman_timeserver_add_list(list, service_ts[i]);
 
+#ifdef DEFAULT_GW_SUPPORTS_NTP
 	network = __connman_service_get_network(service);
 	if (network) {
 		index = connman_network_get_index(network);
@@ -214,6 +219,7 @@ GSList *__connman_timeserver_get_all(struct connman_service *service)
 		if (service_gw)
 			list = __connman_timeserver_add_list(list, service_gw);
 	}
+#endif
 
 	/* Then add Global Timeservers to the list */
 	timeservers = load_timeservers();


### PR DESCRIPTION
Upstream is unable to explain this assumption (and yet refusing to take it out)