### PR TITLE
[connman] Mark associating network as available. Contributes to JB#30…

### DIFF
--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -1913,6 +1913,10 @@ static void interface_state(GSupplicantInterface *interface)
 
 	case G_SUPPLICANT_STATE_AUTHENTICATING:
 	case G_SUPPLICANT_STATE_ASSOCIATING:
+		/* Scanning after connection request may have cleared
+		   availability flag for the network being connected to */
+		connman_network_set_available(network, true);
+
 		stop_autoscan(device);
 
 		if (!wifi->connected)


### PR DESCRIPTION
…297.

It may happen that autoscan is triggered after a connection request
has been made. Starting a scan clears networks' availability flags; if
the connection request proceeds to associating state before new scan
results are at hand the associating network may be freed and
connection attempt aborted. This happens even if state change and scan
results are received from supplicant in the same D-Bus signal but
State property is before BSSs in the message.

To avoid connection failure, mark the associating network as available
when state change to associating happens.