### PR TITLE
[connman] Clear disconnecting flag only on callback. Contributes to J…

### DIFF
--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -1965,7 +1965,6 @@ static void interface_state(GSupplicantInterface *interface)
 
 		connman_network_set_connected(network, false);
 		connman_network_set_associating(network, false);
-		wifi->disconnecting = false;
 
 		start_autoscan(device);
 


### PR DESCRIPTION
…B#30297.

As wifi->disconnecting is set to true only when a method call to
supplicant is made, do not clear the flag on interface state change,
but only in the callback. Otherwise, if a network connection is
requested after state change but before disconnection callback gets
called, wifi pending network isn't set properly and connection
progress won't be properly processed.