### PR TITLE
[connman] wifi: Do not add frequency to hidden AP scan. MER#1252

### DIFF
--- a/connman/plugins/wifi.c
+++ b/connman/plugins/wifi.c
@@ -482,7 +482,7 @@ static int get_hidden_connections(GSupplicantScanParams *scan_data)
 	GKeyFile *keyfile;
 	gchar **services;
 	char *ssid, *name;
-	int i, freq, ret;
+	int i, ret;
 	bool value;
 	int num_ssids = 0, add_param_failed = 0;
 
@@ -512,13 +512,10 @@ static int get_hidden_connections(GSupplicantScanParams *scan_data)
 		ssid = g_key_file_get_string(keyfile,
 					services[i], "SSID", NULL);
 
-		freq = g_key_file_get_integer(keyfile, services[i],
-					"Frequency", NULL);
-
 		name = g_key_file_get_string(keyfile, services[i], "Name",
 								NULL);
 
-		ret = add_scan_param(ssid, NULL, 0, freq, scan_data, 0, name);
+		ret = add_scan_param(ssid, NULL, 0, 0, scan_data, 0, name);
 		if (ret < 0)
 			add_param_failed++;
 		else if (ret > 0)


### PR DESCRIPTION
It seems that wpa_supplicant gets confused if we pass frequency
to scan params when trying to connect to hidden AP.

Fixes CM-676