### PR TITLE
[connman] Fix service-files substitution. Fixes MER#1294

### DIFF
--- a/connman/Makefile.am
+++ b/connman/Makefile.am
@@ -462,7 +462,9 @@ EXTRA_DIST += vpn/connman-task.te
 do_subst = $(AM_V_GEN)$(SED) \
 		-e 's,[@]prefix[@],$(prefix),g' \
 		-e 's,[@]sbindir[@],$(sbindir),g' \
-		-e 's,[@]sysconfdir[@],$(sysconfdir),g'
+		-e 's,[@]sysconfdir[@],$(sysconfdir),g' \
+		-e 's,[@]CONNMAN_SERVICE_REQUIRES[@],$(CONNMAN_SERVICE_REQUIRES),g' \
+		-e 's,[@]CONNMAN_SERVICE_AFTER[@],$(CONNMAN_SERVICE_AFTER),g'
 
 %.service: %.service.in Makefile
 	$(AM_V_at)$(MKDIR_P) $(dir $@)


### PR DESCRIPTION
Service files are not anymore generated by AC_OUTPUT, like they
used to be.